### PR TITLE
Refactor integration tests

### DIFF
--- a/buildpacks/dotnet/tests/sdk_installation_test.rs
+++ b/buildpacks/dotnet/tests/sdk_installation_test.rs
@@ -2,59 +2,27 @@ use crate::tests::default_build_config;
 use indoc::indoc;
 use libcnb_test::{assert_contains, assert_empty, TestRunner};
 
-// These are simply a couple of test drafts (to test current behavior of the buildpack itself,
-// as well as running integration tests locally/on GitHub).
-// TODO: Update when logic to determine SDK version is implemented, and allow for multiple archs.
 #[test]
 #[ignore = "integration test"]
+fn test_sdk_installation() {
+    TestRunner::default().build(
+        default_build_config( "tests/fixtures/basic_web_8.0"),
+        |context| {
+            assert_empty!(context.pack_stderr);
+            assert_contains!(
+                context.pack_stdout,
+                &indoc! {r#"
+                    [.NET SDK]
+                    Detected .NET project file: /workspace/foo.csproj
+                    Project type is WebApplication using SDK "Microsoft.NET.Sdk.Web" specifies TFM "net8.0"
+                    Inferred SDK version requirement: ^8.0
+                    Resolved .NET SDK version 8.0."#}
+            );
+        },
+    );
+}
+
 #[cfg(target_arch = "x86_64")]
-fn test_sdk_installation() {
-    TestRunner::default().build(
-        default_build_config( "tests/fixtures/basic_web_8.0"),
-        |context| {
-            assert_empty!(context.pack_stderr);
-            assert_contains!(
-                context.pack_stdout,
-                &indoc! {r#"
-                    [.NET SDK]
-                    Detected .NET project file: /workspace/foo.csproj
-                    Project type is WebApplication using SDK "Microsoft.NET.Sdk.Web" specifies TFM "net8.0"
-                    Inferred SDK version requirement: ^8.0
-                    Resolved .NET SDK version 8.0.300 (linux-amd64)
-                    Downloading .NET SDK version 8.0.300 from https://download.visualstudio.microsoft.com/download/pr/4a252cd9-d7b7-41bf-a7f0-b2b10b45c068/1aff08f401d0e3980ac29ccba44efb29/dotnet-sdk-8.0.300-linux-x64.tar.gz
-                    Verifying checksum
-                    Installing .NET SDK
-                "#}
-            );
-        },
-    );
-}
-
-#[test]
-#[ignore = "integration test"]
-#[cfg(target_arch = "aarch64")]
-fn test_sdk_installation() {
-    TestRunner::default().build(
-        default_build_config( "tests/fixtures/basic_web_8.0"),
-        |context| {
-            assert_empty!(context.pack_stderr);
-            assert_contains!(
-                context.pack_stdout,
-                &indoc! {r#"
-                    [.NET SDK]
-                    Detected .NET project file: /workspace/foo.csproj
-                    Project type is WebApplication using SDK "Microsoft.NET.Sdk.Web" specifies TFM "net8.0"
-                    Inferred SDK version requirement: ^8.0
-                    Resolved .NET SDK version 8.0.300 (linux-arm64)
-                    Downloading .NET SDK version 8.0.300 from https://download.visualstudio.microsoft.com/download/pr/54e5bb2e-bdd6-496d-8aba-4ed14658ee91/34fd7327eadad7611bded51dcda44c35/dotnet-sdk-8.0.300-linux-arm64.tar.gz
-                    Verifying checksum
-                    Installing .NET SDK
-                "#}
-            );
-        },
-    );
-}
-
 #[test]
 #[ignore = "integration test"]
 fn test_sdk_installation_with_global_json() {
@@ -65,10 +33,40 @@ fn test_sdk_installation_with_global_json() {
             assert_contains!(
                 context.pack_stdout,
                 &indoc! {r"
+                    [.NET SDK]
                     Detected .NET project file: /workspace/foo.csproj
                     Detected global.json file in the root directory
                     Inferred SDK version requirement: =8.0.101
-                    Resolved .NET SDK version 8.0.101"}
+                    Resolved .NET SDK version 8.0.101 (linux-amd64)
+                    Downloading .NET SDK version 8.0.101 from https://download.visualstudio.microsoft.com/download/pr/9454f7dc-b98e-4a64-a96d-4eb08c7b6e66/da76f9c6bc4276332b587b771243ae34/dotnet-sdk-8.0.101-linux-x64.tar.gz
+                    Verifying checksum
+                    Installing .NET SDK"
+                }
+            );
+        },
+    );
+}
+
+#[cfg(target_arch = "aarch64")]
+#[test]
+#[ignore = "integration test"]
+fn test_sdk_installation_with_global_json() {
+    TestRunner::default().build(
+        default_build_config("tests/fixtures/basic_web_8.0_with_global_json"),
+        |context| {
+            assert_empty!(context.pack_stderr);
+            assert_contains!(
+                context.pack_stdout,
+                &indoc! {r"
+                    [.NET SDK]
+                    Detected .NET project file: /workspace/foo.csproj
+                    Detected global.json file in the root directory
+                    Inferred SDK version requirement: =8.0.101
+                    Resolved .NET SDK version 8.0.101 (linux-arm64)
+                    Downloading .NET SDK version 8.0.101 from https://download.visualstudio.microsoft.com/download/pr/092bec24-9cad-421d-9b43-458b3a7549aa/84280dbd1eef750f9ed1625339235c22/dotnet-sdk-8.0.101-linux-arm64.tar.gz
+                    Verifying checksum
+                    Installing .NET SDK"
+                }
             );
         },
     );


### PR DESCRIPTION
Use the test project that's pinned to a specific version (i.e. with a global.json file) to test the full integration including arch and download url. Also remove the minor version and arch specific information from the test that run on any platform.

These are minor improvements that reduces the need to maintain these tests as the `inventory.toml` file is updated with new versions. These tests will soon be rewritten to handle both arch and `inventory.toml` changes better.