### PR TITLE
Invoke inventory updater with --package

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Rebuild Inventory
         id: rebuild-inventory
-        run: cargo run --bin inventory-updater buildpacks/dotnet/inventory.toml CHANGELOG.md
+        run: cargo run --package inventory-updater buildpacks/dotnet/inventory.toml CHANGELOG.md
 
       - name: Create Pull Request
         id: pr


### PR DESCRIPTION
This is required as the buildpack crate is now configured as the sole default workspace member https://github.com/heroku/buildpacks-dotnet/commit/6769f5a34b1bc6958b6b5be5f94f7ab7fa04e8ac