### PR TITLE
Explicitly set publish configuration

### DIFF
--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -91,6 +91,8 @@ impl Buildpack for DotnetBuildpack {
                     "publish",
                     "--verbosity",
                     "normal",
+                    "--configuration",
+                    "Release",
                     "--runtime",
                     &dotnet_rid::get_runtime_identifier().to_string(),
                 ])


### PR DESCRIPTION
Since .NET 8.0, the `dotnet publish` command will default to the "Release" configuration. We're setting it explicitly here to ensure consistency in the expected output path across .NET versions (although we don't plan on supporting < NET 8.0), and to make it clear that this is configurable. Also see https://github.com/heroku/buildpacks-dotnet/issues/22