### PR TITLE
Parse project AssemblyName value

### DIFF
--- a/buildpacks/dotnet/src/dotnet_project.rs
+++ b/buildpacks/dotnet/src/dotnet_project.rs
@@ -34,6 +34,7 @@ pub(crate) struct DotnetProject {
     pub(crate) sdk_id: String,
     pub(crate) target_framework: String,
     pub(crate) project_type: ProjectType,
+    pub(crate) assembly_name: Option<String>,
 }
 
 /// Enum representing possible errors that can occur during parsing.
@@ -68,6 +69,7 @@ impl FromStr for DotnetProject {
         let mut sdk_id = String::new();
         let mut target_framework = String::new();
         let mut project_type = ProjectType::Unknown;
+        let mut assembly_name = None;
 
         for node in doc.descendants() {
             match node.tag_name().name() {
@@ -97,6 +99,13 @@ impl FromStr for DotnetProject {
                         _ => ProjectType::Unknown,
                     };
                 }
+                "AssemblyName" => {
+                    if let Some(text) = node.text() {
+                        if !text.is_empty() {
+                            assembly_name = Some(text.to_string());
+                        }
+                    }
+                }
                 _ => (),
             }
         }
@@ -117,6 +126,7 @@ impl FromStr for DotnetProject {
             sdk_id,
             target_framework,
             project_type,
+            assembly_name,
         })
     }
 }
@@ -140,6 +150,7 @@ mod tests {
         assert_eq!(project.sdk_id, "Microsoft.NET.Sdk");
         assert_eq!(project.target_framework, "net6.0");
         assert_eq!(project.project_type, ProjectType::ConsoleApplication);
+        assert_eq!(project.assembly_name, None);
     }
 
     #[test]
@@ -155,6 +166,7 @@ mod tests {
         assert_eq!(project.sdk_id, "Microsoft.NET.Sdk.Web");
         assert_eq!(project.target_framework, "net6.0");
         assert_eq!(project.project_type, ProjectType::WebApplication);
+        assert_eq!(project.assembly_name, None);
     }
 
     #[test]
@@ -171,6 +183,7 @@ mod tests {
         assert_eq!(project.sdk_id, "Microsoft.NET.Sdk.Razor");
         assert_eq!(project.target_framework, "net6.0");
         assert_eq!(project.project_type, ProjectType::RazorApplication);
+        assert_eq!(project.assembly_name, None);
     }
 
     #[test]
@@ -187,6 +200,7 @@ mod tests {
         assert_eq!(project.sdk_id, "Microsoft.NET.Sdk.BlazorWebAssembly");
         assert_eq!(project.target_framework, "net6.0");
         assert_eq!(project.project_type, ProjectType::BlazorWebAssembly);
+        assert_eq!(project.assembly_name, None);
     }
 
     #[test]
@@ -203,6 +217,7 @@ mod tests {
         assert_eq!(project.sdk_id, "Microsoft.NET.Sdk.Worker");
         assert_eq!(project.target_framework, "net6.0");
         assert_eq!(project.project_type, ProjectType::Worker);
+        assert_eq!(project.assembly_name, None);
     }
 
     #[test]
@@ -218,6 +233,24 @@ mod tests {
         assert_eq!(project.sdk_id, "Microsoft.NET.Sdk");
         assert_eq!(project.target_framework, "net6.0");
         assert_eq!(project.project_type, ProjectType::Library);
+        assert_eq!(project.assembly_name, None);
+    }
+
+    #[test]
+    fn test_parse_project_with_assembly_name() {
+        let project_xml = r#"
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <AssemblyName>MyAssembly</AssemblyName>
+    </PropertyGroup>
+</Project>
+"#;
+        let project = project_xml.parse::<DotnetProject>().unwrap();
+        assert_eq!(project.sdk_id, "Microsoft.NET.Sdk");
+        assert_eq!(project.target_framework, "net6.0");
+        assert_eq!(project.project_type, ProjectType::Library);
+        assert_eq!(project.assembly_name, Some("MyAssembly".to_string()));
     }
 
     #[test]
@@ -266,5 +299,6 @@ mod tests {
         assert_eq!(project.sdk_id, "Microsoft.NET.Sdk");
         assert_eq!(project.target_framework, "net6.0");
         assert_eq!(project.project_type, ProjectType::Library);
+        assert_eq!(project.assembly_name, None);
     }
 }

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -55,8 +55,11 @@ pub(crate) fn handle(
 
         // TODO: Remove this (currently here for debugging, and making the linter happy)
         log_info(format!(
-            "Project type is {:?} using SDK \"{}\" specifies TFM \"{}\"",
-            dotnet_project.project_type, dotnet_project.sdk_id, dotnet_project.target_framework
+            "Project type is {:?} using SDK \"{}\" specifies TFM \"{}\" and assembly name \"{}\"",
+            dotnet_project.project_type,
+            dotnet_project.sdk_id,
+            dotnet_project.target_framework,
+            dotnet_project.assembly_name.unwrap_or(String::new())
         ));
         tfm::parse_target_framework(&dotnet_project.target_framework)
             .map_err(SdkLayerError::ParseTargetFramework)?

--- a/buildpacks/dotnet/tests/sdk_installation_test.rs
+++ b/buildpacks/dotnet/tests/sdk_installation_test.rs
@@ -14,7 +14,7 @@ fn test_sdk_resolution_with_target_framework() {
                 &indoc! {r#"
                     [.NET SDK]
                     Detected .NET project file: /workspace/foo.csproj
-                    Project type is WebApplication using SDK "Microsoft.NET.Sdk.Web" specifies TFM "net8.0"
+                    Project type is WebApplication using SDK "Microsoft.NET.Sdk.Web" specifies TFM "net8.0" and assembly name ""
                     Inferred SDK version requirement: ^8.0
                     Resolved .NET SDK version 8.0."#}
             );


### PR DESCRIPTION
In order to determine the expected name of the executable for a project we need to know the assembly name (if defined in the project file)