### PR TITLE
Disable languages CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 # Default to requesting pull request reviews from the Heroku Languages team.
-* @heroku/languages
+# Uncomment when the buildpack is out of development.
+#* @heroku/languages
 
 # Except for automation that:
 # - updates binary inventories


### PR DESCRIPTION
Since whilst the buildpack is in development we're not doing PR reviews, so the email notifications to the team are just noise.

We can enable it again once the buildpack is out of development and ready for review.