### PR TITLE
Implement basic NuGet cache purging

### DIFF
--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -26,7 +26,8 @@ use libcnb::data::layer_name;
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericMetadata, GenericPlatform};
 use libcnb::layer::{
-    CachedLayerDefinition, InvalidMetadataAction, LayerRef, LayerState, RestoredLayerAction,
+    CachedLayerDefinition, EmptyLayerCause, InvalidMetadataAction, LayerRef, LayerState,
+    RestoredLayerAction,
 };
 use libcnb::layer_env::Scope;
 use libcnb::{buildpack_main, Buildpack, Env, Target};
@@ -233,12 +234,15 @@ fn resolve_sdk_artifact(
 
 #[derive(Serialize, Deserialize)]
 struct NugetCacheLayerMetadata {
-    version: String,
+    // Using float here due to [an issue with lifecycle's handling of integers](https://github.com/buildpacks/lifecycle/issues/884)
+    restore_count: f32,
 }
+
+const MAX_NUGET_CACHE_RESTORE_COUNT: f32 = 10.0;
 
 fn handle_nuget_cache_layer(
     context: &BuildContext<DotnetBuildpack>,
-) -> Result<LayerRef<DotnetBuildpack, (), ()>, libcnb::Error<<DotnetBuildpack as Buildpack>::Error>>
+) -> Result<LayerRef<DotnetBuildpack, (), f32>, libcnb::Error<<DotnetBuildpack as Buildpack>::Error>>
 {
     let nuget_cache_layer = context.cached_layer(
         layer_name!("nuget-cache"),
@@ -246,18 +250,41 @@ fn handle_nuget_cache_layer(
             build: false,
             launch: false,
             invalid_metadata_action: &|_| InvalidMetadataAction::DeleteLayer,
-            restored_layer_action: &|_metadata: &NugetCacheLayerMetadata, _path| {
-                RestoredLayerAction::KeepLayer
+            restored_layer_action: &|metadata: &NugetCacheLayerMetadata, _path| {
+                if metadata.restore_count > MAX_NUGET_CACHE_RESTORE_COUNT {
+                    (RestoredLayerAction::DeleteLayer, metadata.restore_count)
+                } else {
+                    (RestoredLayerAction::KeepLayer, metadata.restore_count)
+                }
             },
         },
     )?;
     match nuget_cache_layer.state {
-        LayerState::Restored { .. } => log_info("Reusing NuGet package cache"),
-        LayerState::Empty { .. } => {
-            log_info("Empty NuGet package cache");
+        LayerState::Restored {
+            cause: restore_count,
+        } => {
+            log_info("Reusing NuGet package cache");
             nuget_cache_layer.write_metadata(NugetCacheLayerMetadata {
-                version: String::from("foo"),
+                restore_count: restore_count + 1.0,
             })?;
+        }
+        LayerState::Empty { cause } => {
+            match cause {
+                EmptyLayerCause::NewlyCreated => {
+                    log_info("Created NuGet package cache");
+                }
+                EmptyLayerCause::InvalidMetadataAction { .. } => {
+                    log_info("Purged NuGet package cache due to invalid metadata");
+                }
+                EmptyLayerCause::RestoredLayerAction {
+                    cause: restore_count,
+                } => {
+                    log_info(format!(
+                        "Purged NuGet package cache after {restore_count} builds"
+                    ));
+                }
+            }
+            nuget_cache_layer.write_metadata(NugetCacheLayerMetadata { restore_count: 1.0 })?;
         }
     }
     Ok(nuget_cache_layer)

--- a/buildpacks/dotnet/tests/dotnet_publish_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_publish_test.rs
@@ -21,7 +21,7 @@ fn test_dotnet_publish_with_rid() {
             assert_contains!(
                 replace_msbuild_log_patterns_with_placeholder(&context.pack_stdout, "<PLACEHOLDER>"), 
                 &formatdoc! {r#"
-                Empty NuGet package cache
+                Created NuGet package cache
 
                 [Publish]
                 MSBuild version 17.8.3+195e7f5a3 for .NET

--- a/buildpacks/dotnet/tests/nuget_layer_test.rs
+++ b/buildpacks/dotnet/tests/nuget_layer_test.rs
@@ -12,7 +12,7 @@ fn test_nuget_restore_and_cache() {
             assert_contains!(
                 replace_msbuild_log_patterns_with_placeholder(&context.pack_stdout, "<PLACEHOLDER>"),
                 &indoc! {r#"
-                Empty NuGet package cache
+                Created NuGet package cache
 
                 [Publish]
                 MSBuild version 17.9.8+610b4d3b5 for .NET


### PR DESCRIPTION
This PR adds support for purging the NuGet cache layer after a number of restores (largely inspired by [the yarn buildpack implementation](https://github.com/heroku/buildpacks-nodejs/blob/88d1849598acccb564e18bb6ae2d8ae2a7fcbef4/buildpacks/nodejs-yarn/src/layers/deps.rs)). The max number of restores need to be adjusted (from 10) based on a number of factors -- especially when support for more granular per-package purging (as described in https://github.com/heroku/buildpacks-dotnet/issues/15) is implemented.

However, seeing as NuGet package caches can grow quite a bit over time, we'll likely always want to have a hard layer restore limit count, if only to account for scenarios where other approaches do not purge the cache as expected.