### PR TITLE
Reduce integration test flakiness

### DIFF
--- a/buildpacks/dotnet/tests/nuget_layer_test.rs
+++ b/buildpacks/dotnet/tests/nuget_layer_test.rs
@@ -28,27 +28,7 @@ fn test_nuget_restore_and_cache() {
                            OK https://api.nuget.org/v3-flatcontainer/newtonsoft.json/index.json <PLACEHOLDER>
                            GET https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.3/newtonsoft.json.13.0.3.nupkg
                            OK https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.3/newtonsoft.json.13.0.3.nupkg <PLACEHOLDER>
-                         Installed Newtonsoft.Json 13.0.3 from https://api.nuget.org/v3/index.json to /layers/heroku_dotnet/nuget-cache/newtonsoft.json/13.0.3 with content hash HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ==.
-                           GET https://api.nuget.org/v3/vulnerabilities/index.json
-                           OK https://api.nuget.org/v3/vulnerabilities/index.json <PLACEHOLDER>
-                           GET https://api.nuget.org/v3-vulnerabilities/<PLACEHOLDER>/vulnerability.base.json
-                           GET https://api.nuget.org/v3-vulnerabilities/<PLACEHOLDER>/<PLACEHOLDER>/vulnerability.update.json
-                           OK https://api.nuget.org/v3-vulnerabilities/<PLACEHOLDER>/vulnerability.base.json <PLACEHOLDER>
-                           OK https://api.nuget.org/v3-vulnerabilities/<PLACEHOLDER>/<PLACEHOLDER>/vulnerability.update.json <PLACEHOLDER>
-                         Generating MSBuild file /workspace/obj/consoleapp.csproj.nuget.g.props.
-                         Generating MSBuild file /workspace/obj/consoleapp.csproj.nuget.g.targets.
-                         Writing assets file to disk. Path: /workspace/obj/project.assets.json
-                         Restored /workspace/consoleapp.csproj <PLACEHOLDER>.
-                         
-                         NuGet Config files used:
-                             /home/heroku/.nuget/NuGet/NuGet.Config
-                         
-                         Feeds used:
-                             https://api.nuget.org/v3/index.json
-                         
-                         Installed:
-                             1 package(s) to /workspace/consoleapp.csproj
-                     1>Done Building Project "/workspace/consoleapp.csproj" (Restore target(s))."#}
+                         Installed Newtonsoft.Json 13.0.3 from https://api.nuget.org/v3/index.json to /layers/heroku_dotnet/nuget-cache/newtonsoft.json/13.0.3 with content hash HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ==."#}
             );
 
             // Verify NuGet package layer caching behavior


### PR DESCRIPTION
While this change is not the solution for https://github.com/heroku/buildpacks-dotnet/issues/59, it should reduce the rate of intermittent errors from this particular test for now.