### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,7 +475,7 @@ name = "inventory-updater"
 version = "0.0.0"
 dependencies = [
  "inventory",
- "keep_a_changelog",
+ "keep_a_changelog_file",
  "semver",
  "serde",
  "sha2",
@@ -499,9 +499,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "keep_a_changelog"
+name = "keep_a_changelog_file"
 version = "0.1.0"
-source = "git+https://github.com/heroku/keep_a_changelog?rev=f92ec48c9257ff8d67df1eb8e942a2c25cf2ba91#f92ec48c9257ff8d67df1eb8e942a2c25cf2ba91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516dcf9845c0228e8accdc2c61de18e68a701fcbe045085d96db097bad19d1cc"
 dependencies = [
  "chrono",
  "indexmap",

--- a/shared/inventory-updater/Cargo.toml
+++ b/shared/inventory-updater/Cargo.toml
@@ -9,7 +9,7 @@ workspace = true
 
 [dependencies]
 inventory = { git = "https://github.com/malax/inventory", features = ["sha2", "semver"]}
-keep_a_changelog = { git = "https://github.com/heroku/keep_a_changelog", rev = "f92ec48c9257ff8d67df1eb8e942a2c25cf2ba91" }
+keep_a_changelog_file = "0.1"
 semver = "1.0"
 serde = "1"
 sha2 = "0.10"

--- a/shared/inventory-updater/src/main.rs
+++ b/shared/inventory-updater/src/main.rs
@@ -1,7 +1,7 @@
 use inventory::artifact::{Arch, Artifact, Os};
 use inventory::checksum::Checksum;
 use inventory::inventory::Inventory;
-use keep_a_changelog::{ChangeGroup, Changelog};
+use keep_a_changelog_file::{ChangeGroup, Changelog};
 use semver::Version;
 use serde::Deserialize;
 use sha2::Sha512;


### PR DESCRIPTION
This updates the malax/inventory and keep_a_changelog_file dependencies (which now both include license metadata).