### PR TITLE
Use actions/create-github-app-token instead of heroku/use-app-token

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -14,11 +14,11 @@ jobs:
     name: Update .NET SDK inventory
     runs-on: pub-hk-ubuntu-22.04-small
     steps:
-      - uses: heroku/use-app-token-action@main
+      - uses: actions/create-github-app-token@v1
         id: generate-token
         with:
-          app_id: ${{ vars.LINGUIST_GH_APP_ID }}
-          private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
+          app-id: ${{ vars.LINGUIST_GH_APP_ID }}
+          private-key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
 
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
         id: pr
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ steps.generate-token.outputs.app_token }}
+          token: ${{ steps.generate-token.outputs.token }}
           title: "Update .NET Inventory"
           commit-message: "Update Inventory for heroku/dotnet"
           committer: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
@@ -48,5 +48,5 @@ jobs:
       - name: Configure PR
         if: steps.pr.outputs.pull-request-operation == 'created'
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: gh pr merge --squash --auto "${{ steps.pr.outputs.pull-request-number }}"


### PR DESCRIPTION
The use-app-token action is deprecated: https://github.com/heroku/use-app-token-action/pull/17

<img width="1080" alt="334930895-d73c5548-5bd5-4a0b-9102-cad77f556f06" src="https://github.com/heroku/buildpacks-dotnet/assets/27900/173b01fc-75fe-49f6-8910-3e7109bac487">

GUS-W-16159742