### PR TITLE
Improve NuGet integration test assertions

### DIFF
--- a/buildpacks/dotnet/tests/nuget_layer_test.rs
+++ b/buildpacks/dotnet/tests/nuget_layer_test.rs
@@ -1,6 +1,6 @@
 use crate::tests::{default_build_config, replace_msbuild_log_patterns_with_placeholder};
 use indoc::indoc;
-use libcnb_test::{assert_contains, assert_empty, TestRunner};
+use libcnb_test::{assert_contains, assert_empty, assert_not_contains, TestRunner};
 
 #[test]
 #[ignore = "integration test"]
@@ -35,39 +35,8 @@ fn test_nuget_restore_and_cache() {
             // Verify NuGet package layer caching behavior
             let config = context.config.clone();
             context.rebuild(config, |ctx| {
-                assert_contains!(replace_msbuild_log_patterns_with_placeholder(&ctx.pack_stdout, "<PLACEHOLDER>"),
-                &indoc! {r#"
-                Reusing cached .NET SDK version: 8.0.205
-                Reusing NuGet package cache
-
-                [Publish]
-                MSBuild version 17.9.8+610b4d3b5 for .NET
-                Build started <PLACEHOLDER>.
-                     1>Project "/workspace/consoleapp.csproj" on node 1 (Restore target(s)).
-                     1>_GetAllRestoreProjectPathItems:
-                         Determining projects to restore...
-                       Restore:
-                         X.509 certificate chain validation will use the fallback certificate bundle at '/layers/heroku_dotnet/sdk/sdk/8.0.205/trustedroots/codesignctl.pem'.
-                         X.509 certificate chain validation will use the fallback certificate bundle at '/layers/heroku_dotnet/sdk/sdk/8.0.205/trustedroots/timestampctl.pem'.
-                         Restoring packages for /workspace/consoleapp.csproj...
-                           GET https://api.nuget.org/v3/vulnerabilities/index.json
-                           OK https://api.nuget.org/v3/vulnerabilities/index.json <PLACEHOLDER>
-                           GET https://api.nuget.org/v3-vulnerabilities/<PLACEHOLDER>/vulnerability.base.json
-                           GET https://api.nuget.org/v3-vulnerabilities/<PLACEHOLDER>/<PLACEHOLDER>/vulnerability.update.json
-                           OK https://api.nuget.org/v3-vulnerabilities/<PLACEHOLDER>/vulnerability.base.json <PLACEHOLDER>
-                           OK https://api.nuget.org/v3-vulnerabilities/<PLACEHOLDER>/<PLACEHOLDER>/vulnerability.update.json <PLACEHOLDER>
-                         Generating MSBuild file /workspace/obj/consoleapp.csproj.nuget.g.props.
-                         Generating MSBuild file /workspace/obj/consoleapp.csproj.nuget.g.targets.
-                         Writing assets file to disk. Path: /workspace/obj/project.assets.json
-                         Restored /workspace/consoleapp.csproj <PLACEHOLDER>.
-                         
-                         NuGet Config files used:
-                             /home/heroku/.nuget/NuGet/NuGet.Config
-                         
-                         Feeds used:
-                             https://api.nuget.org/v3/index.json
-                     1>Done Building Project "/workspace/consoleapp.csproj" (Restore target(s))."#}
-                );
+                assert_not_contains!(&ctx.pack_stdout, "Installed Newtonsoft.Json 13.0.3");
+                assert_contains!(&ctx.pack_stdout, "Restored /workspace/consoleapp.csproj");
             });
         });
 }


### PR DESCRIPTION
We only need to verify that the NuGet cache layer is used (which is adequately indicated by the absence of the "Installed Newtonsoft.Json 13.0.3" and "Restored /workspace/consoleapp.csproj" msbuild log entries).

This helps reduce the flakiness of this integration test substantially (related to https://github.com/heroku/buildpacks-dotnet/issues/59)