### PR TITLE
Configure project publish dir

### DIFF
--- a/buildpacks/dotnet/CHANGELOG.md
+++ b/buildpacks/dotnet/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The `PublishDir` MSBuild property is now set to `bin/publish` when running `dotnet publish`, to ensure that the publish output for each project is consistently sent to the same location (relative to the project file). This enables writing `Procfile` commands that are compatible with any target OS/arch (i.e. Runtime Identifier (RID)), build configuration (e.g. `Release`/`Debug`) and Target Framework Moniker (TFM). ([#120](https://github.com/heroku/buildpacks-dotnet/pull/120))
+- The `PublishDir` MSBuild property is now set to `bin/publish` when running `dotnet publish`, to ensure that the publish output for each project is consistently sent to the same location (relative to the project file). This enables writing `Procfile` commands that are compatible with any target OS/arch (i.e. Runtime Identifier (RID)), build configuration (e.g. `Release`/`Debug`) and Target Framework Moniker (TFM). ([#120](https://github.com/heroku/buildpacks-dotnet/pull/121))
 
 ## [0.1.1] - 2024-08-19
 

--- a/buildpacks/dotnet/CHANGELOG.md
+++ b/buildpacks/dotnet/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The `PublishDir` MSBuild property is now set to `bin/publish` when running `dotnet publish`, to ensure that the publish output for each project is consistently sent to the same location (relative to the project file). This enables writing `Procfile` commands that are compatible with any target OS/arch (i.e. Runtime Identifier (RID)), build configuration (e.g. `Release`/`Debug`) and Target Framework Moniker (TFM). ([#120](https://github.com/heroku/buildpacks-dotnet/pull/120))
+
 ## [0.1.1] - 2024-08-19
 
 ### Added

--- a/buildpacks/dotnet/src/dotnet_publish_command.rs
+++ b/buildpacks/dotnet/src/dotnet_publish_command.rs
@@ -18,6 +18,7 @@ impl From<DotnetPublishCommand> for Command {
             &value.path.to_string_lossy(),
             "--runtime",
             &value.runtime_identifier.to_string(),
+            "-p:PublishDir=bin/publish",
         ]);
 
         if let Some(configuration) = value.configuration {

--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -1,5 +1,4 @@
 use crate::dotnet::project::ProjectType;
-use crate::dotnet::runtime_identifier::RuntimeIdentifier;
 use crate::dotnet::solution::Solution;
 use libcnb::data::launch::{
     Process, ProcessBuilder, ProcessType, ProcessTypeError, WorkingDirectory,
@@ -12,8 +11,6 @@ pub(crate) enum LaunchProcessDetectionError {
 
 pub(crate) fn detect_solution_processes(
     solution: &Solution,
-    configuration: &str,
-    runtime_identifier: &RuntimeIdentifier,
 ) -> Result<Vec<Process>, LaunchProcessDetectionError> {
     solution
         .projects
@@ -32,9 +29,6 @@ pub(crate) fn detect_solution_processes(
                 .parent()
                 .expect("Project file should always have a parent directory")
                 .join("bin")
-                .join(configuration)
-                .join(&project.target_framework)
-                .join(runtime_identifier.to_string())
                 .join("publish")
                 .join(&project.assembly_name);
             let mut command = format!("{}", executable_path.to_string_lossy());

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -142,12 +142,10 @@ impl Buildpack for DotnetBuildpack {
             style::value(build_configuration.clone())
         ));
 
-        let runtime_identifier = runtime_identifier::get_runtime_identifier(target_os, target_arch);
-
         let mut publish_command = Command::from(DotnetPublishCommand {
             path: solution.path.clone(),
             configuration: buildpack_configuration.build_configuration,
-            runtime_identifier,
+            runtime_identifier: runtime_identifier::get_runtime_identifier(target_os, target_arch),
             verbosity_level: buildpack_configuration.msbuild_verbosity_level,
         });
         publish_command

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -143,11 +143,7 @@ impl Buildpack for DotnetBuildpack {
         ));
 
         let runtime_identifier = runtime_identifier::get_runtime_identifier(target_os, target_arch);
-        let launch_processes_result = launch_process::detect_solution_processes(
-            &solution,
-            &build_configuration,
-            &runtime_identifier,
-        );
+        let launch_processes_result = launch_process::detect_solution_processes(&solution);
 
         let mut publish_command = Command::from(DotnetPublishCommand {
             path: solution.path,

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -143,10 +143,9 @@ impl Buildpack for DotnetBuildpack {
         ));
 
         let runtime_identifier = runtime_identifier::get_runtime_identifier(target_os, target_arch);
-        let launch_processes_result = launch_process::detect_solution_processes(&solution);
 
         let mut publish_command = Command::from(DotnetPublishCommand {
-            path: solution.path,
+            path: solution.path.clone(),
             configuration: buildpack_configuration.build_configuration,
             runtime_identifier,
             verbosity_level: buildpack_configuration.msbuild_verbosity_level,
@@ -166,7 +165,7 @@ impl Buildpack for DotnetBuildpack {
         layers::runtime::handle(&context, &sdk_layer.path())?;
 
         let mut build_result_builder = BuildResultBuilder::new();
-        match launch_processes_result {
+        match launch_process::detect_solution_processes(&solution) {
             Ok(processes) => {
                 // TODO: Print log information about registered processes
                 build_result_builder =

--- a/buildpacks/dotnet/tests/dotnet_publish_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_publish_test.rs
@@ -19,16 +19,13 @@ fn test_dotnet_publish_multi_tfm_solution() {
             );
             assert_contains!(
                 context.pack_stdout,
-                &format! {"worker -> /workspace/worker/bin/Release/net6.0/{rid}/publish/" }
+                "worker -> /workspace/worker/bin/publish/"
             );
             assert_contains!(
                 context.pack_stdout,
                 &format! {"web -> /workspace/web/bin/Release/net8.0/{rid}/web.dll" }
             );
-            assert_contains!(
-                context.pack_stdout,
-                &format! {"web -> /workspace/web/bin/Release/net8.0/{rid}/publish/" }
-            );
+            assert_contains!(context.pack_stdout, "web -> /workspace/web/bin/publish/");
         },
     );
 }
@@ -53,7 +50,7 @@ fn test_dotnet_publish_with_debug_configuration() {
                           Determining projects to restore...
                           Restored /workspace/foo.csproj <PLACEHOLDER>.
                           foo -> /workspace/bin/Debug/net8.0/{rid}/foo.dll
-                          foo -> /workspace/bin/Debug/net8.0/{rid}/publish/"#}
+                          foo -> /workspace/bin/publish/"#}
             );
         },
     );
@@ -74,7 +71,7 @@ fn test_dotnet_publish_with_global_json_and_custom_verbosity_level() {
               &formatdoc! {r#"
                 - Publish solution
                   - Using `Release` build configuration
-                  - Running `dotnet publish /workspace/foo.csproj --runtime {rid} --verbosity normal`
+                  - Running `dotnet publish /workspace/foo.csproj --runtime {rid} "-p:PublishDir=bin/publish" --verbosity normal`
                 
                       MSBuild version 17.8.3+195e7f5a3 for .NET
                       Build started <PLACEHOLDER>.


### PR DESCRIPTION
The `PublishDir` MSBuild property is now set to `bin/publish` when running `dotnet publish`, to ensure that the publish output for each project is consistently sent to the same location (relative to the project file).

This enables writing `Procfile` commands that are compatible with any target OS/arch (i.e. Runtime Identifier (RID)), build configuration (e.g. `Release`/`Debug`) and Target Framework Moniker (TFM).