### PR TITLE
Increase NuGet cache layer restore limit

### DIFF
--- a/buildpacks/dotnet/src/layers/nuget_cache.rs
+++ b/buildpacks/dotnet/src/layers/nuget_cache.rs
@@ -15,7 +15,7 @@ struct NugetCacheLayerMetadata {
     restore_count: f32,
 }
 
-const MAX_NUGET_CACHE_RESTORE_COUNT: f32 = 10.0;
+const MAX_NUGET_CACHE_RESTORE_COUNT: f32 = 20.0;
 
 type HandleResult = Result<
     (


### PR DESCRIPTION
This PR simply increases the number of times the NuGet cache layer can be restored (before being purged) from 10 to 20. Related to https://github.com/heroku/buildpacks-dotnet/issues/15