### PR TITLE
Use relative launch process paths

### DIFF
--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -50,7 +50,14 @@ pub(crate) fn detect_solution_processes(
                         .working_directory(WorkingDirectory::Directory(
                             executable_path
                                 .parent()
-                                .expect("Executable should always have a parent directory")
+                                .expect("Executable path to always have a parent directory")
+                                .strip_prefix(
+                                    solution
+                                        .path
+                                        .parent()
+                                        .expect("Solution path to have a parent"),
+                                )
+                                .expect("Project to be nested in solution parent directory")
                                 .to_path_buf(),
                         ))
                         .build()

--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -31,7 +31,11 @@ pub(crate) fn detect_solution_processes(
                 .join("bin")
                 .join("publish")
                 .join(&project.assembly_name);
-            let mut command = executable_path.to_string_lossy().to_string();
+            let mut command = executable_path
+                .file_name()
+                .expect("Executable path to never terminate in `..`")
+                .to_string_lossy()
+                .to_string();
 
             if project.project_type == ProjectType::WebApplication {
                 command.push_str(" --urls http://0.0.0.0:$PORT");
@@ -42,7 +46,7 @@ pub(crate) fn detect_solution_processes(
                 .parse::<ProcessType>()
                 .map_err(LaunchProcessDetectionError::ProcessType)
                 .map(|process_type| {
-                    ProcessBuilder::new(process_type, ["bash", "-c", &command])
+                    ProcessBuilder::new(process_type, ["bash", "-c", &format!("./{}", &command)])
                         .working_directory(WorkingDirectory::Directory(
                             executable_path
                                 .parent()

--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -41,7 +41,7 @@ pub(crate) fn detect_solution_processes(
                 )
                 .expect("Project to be nested in solution parent directory");
 
-            let mut command = executable_path
+            let mut command = relative_executable_path
                 .file_name()
                 .expect("Executable path to never terminate in `..`")
                 .to_string_lossy()

--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -31,6 +31,16 @@ pub(crate) fn detect_solution_processes(
                 .join("bin")
                 .join("publish")
                 .join(&project.assembly_name);
+
+            let relative_executable_path = executable_path
+                .strip_prefix(
+                    solution
+                        .path
+                        .parent()
+                        .expect("Solution path to have a parent"),
+                )
+                .expect("Project to be nested in solution parent directory");
+
             let mut command = executable_path
                 .file_name()
                 .expect("Executable path to never terminate in `..`")
@@ -48,16 +58,9 @@ pub(crate) fn detect_solution_processes(
                 .map(|process_type| {
                     ProcessBuilder::new(process_type, ["bash", "-c", &format!("./{}", &command)])
                         .working_directory(WorkingDirectory::Directory(
-                            executable_path
+                            relative_executable_path
                                 .parent()
                                 .expect("Executable path to always have a parent directory")
-                                .strip_prefix(
-                                    solution
-                                        .path
-                                        .parent()
-                                        .expect("Solution path to have a parent"),
-                                )
-                                .expect("Project to be nested in solution parent directory")
                                 .to_path_buf(),
                         ))
                         .build()


### PR DESCRIPTION
This PR changes the command and working directory paths from absolute to relative. This avoids potential issues when using the buildpack in environments where the buildpack's build executable is executed from different directory than the runtime image (e.g. running `bin/build` from `/tmp/build.foo` rather than `/workspace` or `/app`).