### PR TITLE
Add sdk download retry logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "bullet_stream"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec939946cfeb7d4ba709fb24f035a14b78b89641cd4a09434a6d317c0ae28a6"
+checksum = "1e038a9e6b7e36319ab42141434b0c7a93f7714aa90abf63cc5086e106027bb7"
 
 [[package]]
 name = "bumpalo"

--- a/buildpacks/dotnet/CHANGELOG.md
+++ b/buildpacks/dotnet/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The buildpack will now retry SDK downloads when the request failure is caused by I/O errors. ([#140](https://github.com/heroku/buildpacks-dotnet/pull/140))
+
 ## [0.1.4] - 2024-10-09
 
 ### Added

--- a/buildpacks/dotnet/Cargo.toml
+++ b/buildpacks/dotnet/Cargo.toml
@@ -10,7 +10,7 @@ autotests = false
 workspace = true
 
 [dependencies]
-bullet_stream = "0.2.0"
+bullet_stream = "0.3.0"
 fun_run = "0.2.0"
 hex = "0.4"
 indoc = "2"

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -90,10 +90,10 @@ pub(crate) fn handle(
                 style::url(artifact.clone().url)
             ));
 
-            let path = temp_dir().as_path().join("dotnetsdk.tar.gz");
+            let tarball_path = temp_dir().as_path().join("dotnetsdk.tar.gz");
             let mut download_attempts = 0;
             loop {
-                match download_file(&artifact.url, &path) {
+                match download_file(&artifact.url, &tarball_path) {
                     Err(DownloadError::IoError(error)) if download_attempts < 1 => {
                         log_bullet = log_background_bullet.cancel(format!("{error}"));
                         download_attempts += 1;
@@ -109,11 +109,11 @@ pub(crate) fn handle(
             log_bullet = log_background_bullet.done();
 
             log_bullet = log_bullet.sub_bullet("Verifying SDK checksum");
-            verify_checksum(&artifact.checksum, &path)?;
+            verify_checksum(&artifact.checksum, &tarball_path)?;
 
             log_bullet = log_bullet.sub_bullet("Installing SDK");
             decompress_tarball(
-                &mut File::open(&path).map_err(SdkLayerError::OpenArchive)?,
+                &mut File::open(&tarball_path).map_err(SdkLayerError::OpenArchive)?,
                 sdk_layer.path(),
             )
             .map_err(SdkLayerError::DecompressArchive)?;

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -39,6 +39,8 @@ type HandleResult = Result<
     libcnb::Error<DotnetBuildpackError>,
 >;
 
+const MAX_RETRIES: u8 = 1;
+
 pub(crate) fn handle(
     context: &libcnb::build::BuildContext<DotnetBuildpack>,
     log: Print<state::Bullet<Stdout>>,
@@ -92,9 +94,9 @@ pub(crate) fn handle(
 
             let tarball_path = temp_dir().join("dotnetsdk.tar.gz");
             let mut download_attempts = 0;
-            loop {
+            while download_attempts <= MAX_RETRIES {
                 match download_file(&artifact.url, &tarball_path) {
-                    Err(DownloadError::IoError(error)) if download_attempts < 1 => {
+                    Err(DownloadError::IoError(error)) if download_attempts < MAX_RETRIES => {
                         log_bullet = log_background_bullet.cancel(format!("{error}"));
                         download_attempts += 1;
                         thread::sleep(Duration::from_secs(1));

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -93,7 +93,7 @@ pub(crate) fn handle(
             let path = temp_dir().as_path().join("dotnetsdk.tar.gz");
             let mut download_attempts = 0;
             loop {
-                match download_file(&artifact.url, path.clone()) {
+                match download_file(&artifact.url, &path) {
                     Err(DownloadError::IoError(error)) if download_attempts < 1 => {
                         log_bullet = log_background_bullet.cancel(format!("{error}"));
                         download_attempts += 1;
@@ -109,11 +109,11 @@ pub(crate) fn handle(
             log_bullet = log_background_bullet.done();
 
             log_bullet = log_bullet.sub_bullet("Verifying SDK checksum");
-            verify_checksum(&artifact.checksum, path.clone())?;
+            verify_checksum(&artifact.checksum, &path)?;
 
             log_bullet = log_bullet.sub_bullet("Installing SDK");
             decompress_tarball(
-                &mut File::open(path.clone()).map_err(SdkLayerError::OpenArchive)?,
+                &mut File::open(&path).map_err(SdkLayerError::OpenArchive)?,
                 sdk_layer.path(),
             )
             .map_err(SdkLayerError::DecompressArchive)?;

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -90,7 +90,7 @@ pub(crate) fn handle(
                 style::url(artifact.clone().url)
             ));
 
-            let tarball_path = temp_dir().as_path().join("dotnetsdk.tar.gz");
+            let tarball_path = temp_dir().join("dotnetsdk.tar.gz");
             let mut download_attempts = 0;
             loop {
                 match download_file(&artifact.url, &tarball_path) {


### PR DESCRIPTION
This PR adds simple retry logic when SDK downloads fail due to an I/O error, to better handle unexpected connection issues during downloads.

We may want to add additional logic in the future (to retry for instance HTTP 429 and HTTP 503 responses), or limit the I/O error retries to just connection resets or unexpected EOF. I've also only allowed one retry after 1 second, which we may also want to increase.

The `bullet_stream` crate was bumped to `0.3.0` to leverage https://github.com/schneems/bullet_stream/pull/10.