### PR TITLE
Prefer plain detect failure output

### DIFF
--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -34,7 +34,7 @@ use libcnb::{buildpack_main, Buildpack, Env};
 use libherokubuildpack::inventory;
 use semver::{Version, VersionReq};
 use sha2::Sha512;
-use std::io::Stdout;
+use std::io::{Stdout, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::{fs, io};
@@ -50,10 +50,8 @@ impl Buildpack for DotnetBuildpack {
         detect::get_files_with_extensions(&context.app_dir, &["sln", "csproj", "vbproj", "fsproj"])
             .map(|paths| {
                 if paths.is_empty() {
-                    Print::new(std::io::stdout())
-                        .without_header()
-                        .warning("No .NET solution or project files (such as `foo.sln` or `foo.csproj`) found.")
-                        .done();
+                    println!("No .NET solution or project files (such as `foo.sln` or `foo.csproj`) found.");
+                    std::io::stdout().flush().expect("Couldn't flush output stream");
                     DetectResultBuilder::fail().build()
                 } else {
                     DetectResultBuilder::pass().build()

--- a/buildpacks/dotnet/tests/detect_test.rs
+++ b/buildpacks/dotnet/tests/detect_test.rs
@@ -11,10 +11,8 @@ fn detect_rejects_non_dotnet_projects() {
             assert_contains!(
                 context.pack_stdout,
                 indoc! {"========
-
-                    ! No .NET solution or project files (such as `foo.sln` or `foo.csproj`) found.
-
-                    - Done (finished in <"}
+                    No .NET solution or project files (such as `foo.sln` or `foo.csproj`) found.
+                    ======== Results ========"}
             );
         },
     );


### PR DESCRIPTION
The build currently writes "custom" output when `detect` fails, e.g.:

```console
======== Output: heroku/dotnet@0.1.4 ========

! No .NET solution or project files (such as `foo.sln` or `foo.csproj`) found.

- Done (finished in < 0.1s)
======== Results ========
```

This PR adopts the approach used by other buildpacks that print output (e.g., `heroku/php` and `heroku/python`) so output from our builders will be more consistent, e.g.:

```console
======== Output: heroku/php@0.2.0 ========
No PHP project files found.
======== Results ========
fail: heroku/php@0.2.0
skip: heroku/procfile@3.1.2
======== Output: heroku/dotnet@0.1.4 ========
No .NET solution or project files (such as `foo.sln` or `foo.csproj`) found.
======== Results ========
fail: heroku/dotnet@0.1.4
skip: heroku/procfile@3.1.2
```