### PR TITLE
Verify TFM 9.0 SDK resolution

### DIFF
--- a/buildpacks/dotnet/tests/fixtures/basic_web_9.0/Program.cs
+++ b/buildpacks/dotnet/tests/fixtures/basic_web_9.0/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello World!");
+
+app.Run();

--- a/buildpacks/dotnet/tests/fixtures/basic_web_9.0/foo.csproj
+++ b/buildpacks/dotnet/tests/fixtures/basic_web_9.0/foo.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>
+

--- a/buildpacks/dotnet/tests/sdk_installation_test.rs
+++ b/buildpacks/dotnet/tests/sdk_installation_test.rs
@@ -24,6 +24,26 @@ fn test_sdk_resolution_with_target_framework_8_0() {
 
 #[test]
 #[ignore = "integration test"]
+fn test_sdk_resolution_with_target_framework_9_0() {
+    TestRunner::default().build(
+        default_build_config("tests/fixtures/basic_web_9.0"),
+        |context| {
+            assert_empty!(context.pack_stderr);
+            assert_contains!(
+                context.pack_stdout,
+                &indoc! {r"
+                    - SDK version detection
+                      - Detected .NET file to publish: `/workspace/foo.csproj`
+                      - Inferring version requirement from `/workspace/foo.csproj`
+                      - Detected version requirement: `^9.0`
+                      - Resolved .NET SDK version `9.0"}
+            );
+        },
+    );
+}
+
+#[test]
+#[ignore = "integration test"]
 fn test_sdk_resolution_with_solution_file() {
     TestRunner::default().build(
         default_build_config("tests/fixtures/solution_with_web_and_console_projects"),

--- a/buildpacks/dotnet/tests/sdk_installation_test.rs
+++ b/buildpacks/dotnet/tests/sdk_installation_test.rs
@@ -4,7 +4,7 @@ use libcnb_test::{assert_contains, assert_empty, TestRunner};
 
 #[test]
 #[ignore = "integration test"]
-fn test_sdk_resolution_with_target_framework() {
+fn test_sdk_resolution_with_target_framework_8_0() {
     TestRunner::default().build(
         default_build_config("tests/fixtures/basic_web_8.0"),
         |context| {


### PR DESCRIPTION
This PR adds a simple integration test that is currently expected to fail (until `buildpacks/dotnet/inventory.toml` includes a (non-prerelease) SDK artifact for .NET 9.0).

This branch will be rebased on `main` when the inventory includes the required artifact, but I've marked it ready for review (as the PR can't be merged before the test succeeds anyway).