### PR TITLE
Verify global.json prerelease behavior

### DIFF
--- a/buildpacks/dotnet/src/dotnet/global_json.rs
+++ b/buildpacks/dotnet/src/dotnet/global_json.rs
@@ -116,7 +116,7 @@ mod tests {
             TestCase {
                 version: "6.0.100",
                 roll_forward: None,
-                expected: "6.0.100",
+                expected: "^6.0.100",
             },
         ];
 
@@ -127,8 +127,11 @@ mod tests {
             };
             let global_json = GlobalJson { sdk: sdk_config };
             let result = VersionReq::try_from(global_json).unwrap();
-            let expected = VersionReq::parse(case.expected).unwrap();
-            assert_eq!(result, expected, "Failed for case: {case:?}");
+            assert_eq!(
+                result.to_string(),
+                case.expected,
+                "Failed for case: {case:?}"
+            );
         }
     }
 

--- a/buildpacks/dotnet/src/dotnet/global_json.rs
+++ b/buildpacks/dotnet/src/dotnet/global_json.rs
@@ -114,9 +114,19 @@ mod tests {
                 expected: "=6.0.100",
             },
             TestCase {
+                version: "6.0.100-rc.1.12345.1",
+                roll_forward: Some("disable"),
+                expected: "=6.0.100-rc.1.12345.1",
+            },
+            TestCase {
                 version: "6.0.100",
                 roll_forward: None,
                 expected: "^6.0.100",
+            },
+            TestCase {
+                version: "6.0.100-rc.1.12345.1",
+                roll_forward: None,
+                expected: "^6.0.100-rc.1.12345.1",
             },
         ];
 

--- a/buildpacks/dotnet/tests/fixtures/basic_web_9.0_with_global_json_prerelease_sdk/Program.cs
+++ b/buildpacks/dotnet/tests/fixtures/basic_web_9.0_with_global_json_prerelease_sdk/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello World!");
+
+app.Run();

--- a/buildpacks/dotnet/tests/fixtures/basic_web_9.0_with_global_json_prerelease_sdk/foo.csproj
+++ b/buildpacks/dotnet/tests/fixtures/basic_web_9.0_with_global_json_prerelease_sdk/foo.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/buildpacks/dotnet/tests/fixtures/basic_web_9.0_with_global_json_prerelease_sdk/global.json
+++ b/buildpacks/dotnet/tests/fixtures/basic_web_9.0_with_global_json_prerelease_sdk/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+        "version": "9.0.100-rc.1.24452.12",
+        "rollForward": "disable"
+    }
+}

--- a/buildpacks/dotnet/tests/sdk_installation_test.rs
+++ b/buildpacks/dotnet/tests/sdk_installation_test.rs
@@ -110,3 +110,24 @@ fn test_sdk_installation_with_global_json() {
         },
     );
 }
+
+#[test]
+#[ignore = "integration test"]
+fn test_sdk_installation_with_global_json_prerelease_sdk() {
+    TestRunner::default().build(
+        default_build_config("tests/fixtures/basic_web_9.0_with_global_json_prerelease_sdk"),
+        |context| {
+            assert_empty!(context.pack_stderr);
+            assert_contains!(
+                context.pack_stdout,
+                &indoc! {r"
+                    - SDK version detection
+                      - Detected .NET file to publish: `/workspace/foo.csproj`
+                      - Detecting version requirement from root global.json file
+                      - Detected version requirement: `=9.0.100-rc.1.24452.12`
+                      - Resolved .NET SDK version `9.0.100-rc.1.24452.12`"
+                }
+            );
+        },
+    );
+}


### PR DESCRIPTION
While we currently do not consider [the `allowPrerelease` flag](https://github.com/heroku/buildpacks-dotnet/blob/83947ed20b404aaed9599a27982c617c426eabc3/README.md#net-version) in `global.json` files, and never consider pre-release versions based on the `targetFramework` value, users may still explicitly specify pre-release SDK versions in `global.json` to force installation of those releases.

This PR verifies the expected/current behavior, with improvements to the `global.json` unit test assertions and an additional end-to-end integration test.