### PR TITLE
Improve NuGet cache log output

### DIFF
--- a/buildpacks/dotnet/src/layers/nuget_cache.rs
+++ b/buildpacks/dotnet/src/layers/nuget_cache.rs
@@ -53,14 +53,14 @@ pub(crate) fn handle(
     })?;
 
     let log_message = match nuget_cache_layer.state {
-        LayerState::Restored { .. } => Some("Reusing NuGet package cache".to_string()),
+        LayerState::Restored { .. } => Some("Reusing package cache".to_string()),
         LayerState::Empty { cause } => match cause {
             EmptyLayerCause::NewlyCreated => None,
             EmptyLayerCause::InvalidMetadataAction { .. } => {
-                Some("Purging NuGet package cache due to invalid metadata".to_string())
+                Some("Purging package cache due to invalid metadata".to_string())
             }
             EmptyLayerCause::RestoredLayerAction { cause: count } => {
-                Some(format!("Purging NuGet package cache after {count} uses"))
+                Some(format!("Purging package cache after {count} uses"))
             }
         },
     };

--- a/buildpacks/dotnet/src/layers/nuget_cache.rs
+++ b/buildpacks/dotnet/src/layers/nuget_cache.rs
@@ -57,10 +57,10 @@ pub(crate) fn handle(
         LayerState::Empty { cause } => match cause {
             EmptyLayerCause::NewlyCreated => None,
             EmptyLayerCause::InvalidMetadataAction { .. } => {
-                Some("Purged NuGet package cache due to invalid metadata".to_string())
+                Some("Purging NuGet package cache due to invalid metadata".to_string())
             }
             EmptyLayerCause::RestoredLayerAction { cause: count } => {
-                Some(format!("Purged NuGet package cache after {count} uses"))
+                Some(format!("Purging NuGet package cache after {count} uses"))
             }
         },
     };

--- a/buildpacks/dotnet/src/layers/nuget_cache.rs
+++ b/buildpacks/dotnet/src/layers/nuget_cache.rs
@@ -36,7 +36,7 @@ pub(crate) fn handle(
             launch: false,
             invalid_metadata_action: &|_| InvalidMetadataAction::DeleteLayer,
             restored_layer_action: &|metadata: &NugetCacheLayerMetadata, _path| {
-                if metadata.restore_count > MAX_NUGET_CACHE_RESTORE_COUNT {
+                if metadata.restore_count >= MAX_NUGET_CACHE_RESTORE_COUNT {
                     (RestoredLayerAction::DeleteLayer, metadata.restore_count)
                 } else {
                     (RestoredLayerAction::KeepLayer, metadata.restore_count)
@@ -48,7 +48,7 @@ pub(crate) fn handle(
     nuget_cache_layer.write_metadata(NugetCacheLayerMetadata {
         restore_count: match nuget_cache_layer.state {
             LayerState::Restored { cause: count } => count + 1.0,
-            LayerState::Empty { .. } => 1.0,
+            LayerState::Empty { .. } => 0.0,
         },
     })?;
 
@@ -60,7 +60,7 @@ pub(crate) fn handle(
                 Some("Purged NuGet package cache due to invalid metadata".to_string())
             }
             EmptyLayerCause::RestoredLayerAction { cause: count } => {
-                Some(format!("Purged NuGet package cache after {count} builds"))
+                Some(format!("Purged NuGet package cache after {count} uses"))
             }
         },
     };

--- a/buildpacks/dotnet/src/layers/nuget_cache.rs
+++ b/buildpacks/dotnet/src/layers/nuget_cache.rs
@@ -57,10 +57,10 @@ pub(crate) fn handle(
         LayerState::Empty { cause } => match cause {
             EmptyLayerCause::NewlyCreated => None,
             EmptyLayerCause::InvalidMetadataAction { .. } => {
-                Some("Purging package cache due to invalid metadata".to_string())
+                Some("Clearing package cache due to invalid metadata".to_string())
             }
             EmptyLayerCause::RestoredLayerAction { cause: count } => {
-                Some(format!("Purging package cache after {count} uses"))
+                Some(format!("Clearing package cache after {count} uses"))
             }
         },
     };

--- a/buildpacks/dotnet/src/layers/nuget_cache.rs
+++ b/buildpacks/dotnet/src/layers/nuget_cache.rs
@@ -45,11 +45,12 @@ pub(crate) fn handle(
         },
     )?;
 
-    let restore_count = match nuget_cache_layer.state {
-        LayerState::Restored { cause: count } => count + 1.0,
-        LayerState::Empty { .. } => 1.0,
-    };
-    nuget_cache_layer.write_metadata(NugetCacheLayerMetadata { restore_count })?;
+    nuget_cache_layer.write_metadata(NugetCacheLayerMetadata {
+        restore_count: match nuget_cache_layer.state {
+            LayerState::Restored { cause: count } => count + 1.0,
+            LayerState::Empty { .. } => 1.0,
+        },
+    })?;
 
     let log_output = match nuget_cache_layer.state {
         LayerState::Restored { .. } => Some("Reusing NuGet package cache".to_string()),

--- a/buildpacks/dotnet/src/layers/nuget_cache.rs
+++ b/buildpacks/dotnet/src/layers/nuget_cache.rs
@@ -57,7 +57,7 @@ pub(crate) fn handle(
         LayerState::Empty { cause } => {
             nuget_cache_layer.write_metadata(NugetCacheLayerMetadata { restore_count: 1.0 })?;
             match cause {
-                EmptyLayerCause::NewlyCreated => Some("Created NuGet package cache".to_string()),
+                EmptyLayerCause::NewlyCreated => None,
                 EmptyLayerCause::InvalidMetadataAction { .. } => {
                     Some("Purged NuGet package cache due to invalid metadata".to_string())
                 }

--- a/buildpacks/dotnet/src/layers/nuget_cache.rs
+++ b/buildpacks/dotnet/src/layers/nuget_cache.rs
@@ -59,11 +59,9 @@ pub(crate) fn handle(
             EmptyLayerCause::InvalidMetadataAction { .. } => {
                 Some("Purged NuGet package cache due to invalid metadata".to_string())
             }
-            EmptyLayerCause::RestoredLayerAction {
-                cause: restore_count,
-            } => Some(format!(
-                "Purged NuGet package cache after {restore_count} builds"
-            )),
+            EmptyLayerCause::RestoredLayerAction { cause: count } => {
+                Some(format!("Purged NuGet package cache after {count} builds"))
+            }
         },
     };
 

--- a/buildpacks/dotnet/src/layers/nuget_cache.rs
+++ b/buildpacks/dotnet/src/layers/nuget_cache.rs
@@ -52,7 +52,7 @@ pub(crate) fn handle(
         },
     })?;
 
-    let log_message = match nuget_cache_layer.state {
+    if let Some(message) = match nuget_cache_layer.state {
         LayerState::Restored { .. } => Some("Reusing package cache".to_string()),
         LayerState::Empty { cause } => match cause {
             EmptyLayerCause::NewlyCreated => None,
@@ -63,9 +63,7 @@ pub(crate) fn handle(
                 Some(format!("Clearing package cache after {count} uses"))
             }
         },
-    };
-
-    if let Some(message) = log_message {
+    } {
         log = log.bullet("NuGet cache").sub_bullet(message).done();
     }
     Ok((nuget_cache_layer, log))

--- a/buildpacks/dotnet/src/layers/nuget_cache.rs
+++ b/buildpacks/dotnet/src/layers/nuget_cache.rs
@@ -52,7 +52,7 @@ pub(crate) fn handle(
         },
     })?;
 
-    let log_output = match nuget_cache_layer.state {
+    let log_message = match nuget_cache_layer.state {
         LayerState::Restored { .. } => Some("Reusing NuGet package cache".to_string()),
         LayerState::Empty { cause } => match cause {
             EmptyLayerCause::NewlyCreated => None,
@@ -67,7 +67,7 @@ pub(crate) fn handle(
         },
     };
 
-    if let Some(message) = log_output {
+    if let Some(message) = log_message {
         log = log.bullet("NuGet cache").sub_bullet(message).done();
     }
     Ok((nuget_cache_layer, log))

--- a/buildpacks/dotnet/tests/nuget_layer_test.rs
+++ b/buildpacks/dotnet/tests/nuget_layer_test.rs
@@ -9,14 +9,13 @@ fn test_nuget_restore_and_cache() {
           .env("MSBUILD_VERBOSITY_LEVEL", "normal"),
         |context| {
             assert_empty!(context.pack_stderr);
-            assert_contains!(&context.pack_stdout, "Created NuGet package cache");
+            assert_not_contains!(&context.pack_stdout, "NuGet cache");
             assert_contains!(&context.pack_stdout, "Installed Newtonsoft.Json 13.0.3 from https://api.nuget.org/v3/index.json to /layers/heroku_dotnet/nuget-cache/newtonsoft.json/13.0.3 with content hash HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ==.");
             assert_contains!(&context.pack_stdout, "Restored /workspace/consoleapp.csproj");
 
             // Verify NuGet package layer caching behavior
             let config = context.config.clone();
             context.rebuild(config, |rebuild_context| {
-                assert_not_contains!(&rebuild_context.pack_stdout, "Created NuGet package cache");
                 assert_not_contains!(&rebuild_context.pack_stdout, "Installed Newtonsoft.Json 13.0.3");
                 assert_contains!(&rebuild_context.pack_stdout, "Reusing NuGet package cache");
                 assert_contains!(&rebuild_context.pack_stdout, "Restored /workspace/consoleapp.csproj");

--- a/buildpacks/dotnet/tests/nuget_layer_test.rs
+++ b/buildpacks/dotnet/tests/nuget_layer_test.rs
@@ -17,7 +17,7 @@ fn test_nuget_restore_and_cache() {
             let config = context.config.clone();
             context.rebuild(config, |rebuild_context| {
                 assert_not_contains!(&rebuild_context.pack_stdout, "Installed Newtonsoft.Json 13.0.3");
-                assert_contains!(&rebuild_context.pack_stdout, "Reusing NuGet package cache");
+                assert_contains!(&rebuild_context.pack_stdout, "Reusing package cache");
                 assert_contains!(&rebuild_context.pack_stdout, "Restored /workspace/consoleapp.csproj");
             });
         });

--- a/buildpacks/dotnet/tests/nuget_layer_test.rs
+++ b/buildpacks/dotnet/tests/nuget_layer_test.rs
@@ -18,6 +18,7 @@ fn test_nuget_restore_and_cache() {
             context.rebuild(config, |rebuild_context| {
                 assert_not_contains!(&rebuild_context.pack_stdout, "Created NuGet package cache");
                 assert_not_contains!(&rebuild_context.pack_stdout, "Installed Newtonsoft.Json 13.0.3");
+                assert_contains!(&rebuild_context.pack_stdout, "Reusing NuGet package cache");
                 assert_contains!(&rebuild_context.pack_stdout, "Restored /workspace/consoleapp.csproj");
             });
         });


### PR DESCRIPTION
This PR changes the log output so nothing is written when the NuGet cache layer is created for the first time. Printing that the cache has been created provides no substantial value (as it really just reflects the fact that a folder has been created at this stage).

Removing the "NuGet cache" output avoids cluttering the output when the buildpack is first executed (while retaining all relevant messages when the cache is restored/reused/purged etc), and when running pack with the `--clear-cache` flag (and/or when the buildpack is used in an environment that doesn't store/restore the layer cache).

The PR also includes minor changes to terminology, as well as the way the cache restore limit is evaluated, to improve log output and code readability respectively (explained further in the relevant commits).