### PR TITLE
Refactor HandleResult type aliases

### DIFF
--- a/buildpacks/dotnet/src/layers/mod.rs
+++ b/buildpacks/dotnet/src/layers/mod.rs
@@ -3,10 +3,4 @@ pub(crate) mod runtime;
 pub(crate) mod sdk;
 
 pub(crate) type BuildLog = bullet_stream::Print<bullet_stream::state::Bullet<std::io::Stdout>>;
-pub(crate) type LayerLogResult<T> = Result<
-    (
-        libcnb::layer::LayerRef<crate::DotnetBuildpack, (), T>,
-        BuildLog,
-    ),
-    libcnb::Error<crate::DotnetBuildpackError>,
->;
+pub(crate) type DotnetLayerRef<T> = libcnb::layer::LayerRef<crate::DotnetBuildpack, (), T>;

--- a/buildpacks/dotnet/src/layers/mod.rs
+++ b/buildpacks/dotnet/src/layers/mod.rs
@@ -1,3 +1,12 @@
 pub(crate) mod nuget_cache;
 pub(crate) mod runtime;
 pub(crate) mod sdk;
+
+pub(crate) type BuildLog = bullet_stream::Print<bullet_stream::state::Bullet<std::io::Stdout>>;
+pub(crate) type LayerLogResult<T> = Result<
+    (
+        libcnb::layer::LayerRef<crate::DotnetBuildpack, (), T>,
+        BuildLog,
+    ),
+    libcnb::Error<crate::DotnetBuildpackError>,
+>;

--- a/buildpacks/dotnet/src/layers/nuget_cache.rs
+++ b/buildpacks/dotnet/src/layers/nuget_cache.rs
@@ -1,13 +1,11 @@
-use crate::{DotnetBuildpack, DotnetBuildpackError};
-use bullet_stream::{state, Print};
+use crate::layers::{BuildLog, LayerLogResult};
+use crate::DotnetBuildpack;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_name;
 use libcnb::layer::{
-    CachedLayerDefinition, EmptyLayerCause, InvalidMetadataAction, LayerRef, LayerState,
-    RestoredLayerAction,
+    CachedLayerDefinition, EmptyLayerCause, InvalidMetadataAction, LayerState, RestoredLayerAction,
 };
 use serde::{Deserialize, Serialize};
-use std::io::Stdout;
 
 #[derive(Serialize, Deserialize)]
 struct NugetCacheLayerMetadata {
@@ -17,18 +15,10 @@ struct NugetCacheLayerMetadata {
 
 const MAX_NUGET_CACHE_RESTORE_COUNT: f32 = 20.0;
 
-type HandleResult = Result<
-    (
-        LayerRef<DotnetBuildpack, (), f32>,
-        Print<state::Bullet<Stdout>>,
-    ),
-    libcnb::Error<DotnetBuildpackError>,
->;
-
 pub(crate) fn handle(
     context: &BuildContext<DotnetBuildpack>,
-    log: Print<state::Bullet<Stdout>>,
-) -> HandleResult {
+    log: BuildLog,
+) -> LayerLogResult<f32> {
     let nuget_cache_layer = context.cached_layer(
         layer_name!("nuget-cache"),
         CachedLayerDefinition {

--- a/buildpacks/dotnet/src/layers/nuget_cache.rs
+++ b/buildpacks/dotnet/src/layers/nuget_cache.rs
@@ -1,5 +1,5 @@
-use crate::layers::{BuildLog, LayerLogResult};
-use crate::DotnetBuildpack;
+use crate::layers::{BuildLog, DotnetLayerRef};
+use crate::{DotnetBuildpack, DotnetBuildpackError};
 use libcnb::build::BuildContext;
 use libcnb::data::layer_name;
 use libcnb::layer::{
@@ -18,7 +18,7 @@ const MAX_NUGET_CACHE_RESTORE_COUNT: f32 = 20.0;
 pub(crate) fn handle(
     context: &BuildContext<DotnetBuildpack>,
     log: BuildLog,
-) -> LayerLogResult<f32> {
+) -> Result<(DotnetLayerRef<f32>, BuildLog), libcnb::Error<DotnetBuildpackError>> {
     let nuget_cache_layer = context.cached_layer(
         layer_name!("nuget-cache"),
         CachedLayerDefinition {

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -1,4 +1,4 @@
-use crate::layers::{BuildLog, LayerLogResult};
+use crate::layers::{BuildLog, DotnetLayerRef};
 use crate::{dotnet_layer_env, DotnetBuildpack, DotnetBuildpackError};
 use bullet_stream::style;
 use inventory::artifact::Artifact;
@@ -36,7 +36,7 @@ pub(crate) fn handle(
     context: &libcnb::build::BuildContext<DotnetBuildpack>,
     log: BuildLog,
     artifact: &Artifact<Version, Sha512, Option<()>>,
-) -> LayerLogResult<CustomCause> {
+) -> Result<(DotnetLayerRef<CustomCause>, BuildLog), libcnb::Error<DotnetBuildpackError>> {
     let sdk_layer = context.cached_layer(
         layer_name!("sdk"),
         CachedLayerDefinition {


### PR DESCRIPTION
This PR shows how the nearly identical `HandleResult` type aliases used in the SDK and NuGet layers can be removed (either by using a shared alias for a `LayerLogResult`, or aliases for `BuildpackLayerRef` and `BuildLog`) defined in the layers module.

The `HandleResult` type aliases were introduced during the switch to `bullet_stream`, which added significant complexity to some function signatures that needed to pass the output/log back and forth (causing [clippy to balk](https://rust-lang.github.io/rust-clippy/stable/index.html#/type_complexity)).

Defining one or more generic type aliases reduces some duplication, and potentially increases readability (compared to disabling that lint). Curious to hear thoughts on how we can/should approach this?