### PR TITLE
Configure Kestrel wildcard host

### DIFF
--- a/buildpacks/dotnet/CHANGELOG.md
+++ b/buildpacks/dotnet/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Web application launch processes now configure Kestrel to bind both IPv4 and IPv6 addresses. ([#156](https://github.com/heroku/buildpacks-dotnet/pull/156))
+
 ## [0.1.6] - 2024-11-12
 
 ### Added

--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -52,7 +52,7 @@ pub(crate) fn detect_solution_processes(
             );
 
             if project.project_type == ProjectType::WebApplication {
-                command.push_str(" --urls http://0.0.0.0:$PORT");
+                command.push_str(" --urls http://*:$PORT");
             }
 
             project


### PR DESCRIPTION
This configures web application launch processes to bind to all IPv6 and IPv4 addresses. 

Related documentation: https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/endpoints?view=aspnetcore-8.0#url-formats