### PR TITLE
Configure artifacts path to temporary directory

### DIFF
--- a/buildpacks/dotnet/CHANGELOG.md
+++ b/buildpacks/dotnet/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The `sdk` element in detected `global.json` files is no longer required. The SDK version to install is now inferred from the solution/project files when `global.json` doesn't define SDK configuration. ([#202](https://github.com/heroku/buildpacks-dotnet/pull/202))
+- The buildpack will now set `--artifacts-path` to a temporary directory during `dotnet publish`. This change reduces the number of unused, duplicated and/or intermediate files in the app directory. Published output for each project is still written to the same location relative to the the project directory (`bin/publish`, as configured using the `PublishDir` property). ([#186](https://github.com/heroku/buildpacks-dotnet/pull/186))
 
 ## [0.2.2] - 2025-02-12
 

--- a/buildpacks/dotnet/src/dotnet_publish_command.rs
+++ b/buildpacks/dotnet/src/dotnet_publish_command.rs
@@ -1,4 +1,5 @@
 use crate::dotnet::runtime_identifier::RuntimeIdentifier;
+use std::env::temp_dir;
 use std::fmt;
 use std::path::PathBuf;
 use std::process::Command;
@@ -19,6 +20,8 @@ impl From<DotnetPublishCommand> for Command {
             "--runtime",
             &value.runtime_identifier.to_string(),
             "-p:PublishDir=bin/publish",
+            "--artifacts-path",
+            &temp_dir().join("build_artifacts").to_string_lossy(),
         ]);
 
         if let Some(configuration) = value.configuration {

--- a/buildpacks/dotnet/tests/dotnet_publish_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_publish_test.rs
@@ -15,7 +15,7 @@ fn test_dotnet_publish_multi_tfm_solution() {
             assert_contains!(context.pack_stdout, "Detected version requirement: `^8.0`");
             assert_contains!(
                 context.pack_stdout,
-                &format! {"worker -> /workspace/worker/bin/Release/net6.0/{rid}/worker.dll"}
+                &format! {"worker -> /tmp/build_artifacts/bin/worker/release_{rid}/worker.dll"}
             );
             assert_contains!(
                 context.pack_stdout,
@@ -23,7 +23,7 @@ fn test_dotnet_publish_multi_tfm_solution() {
             );
             assert_contains!(
                 context.pack_stdout,
-                &format! {"web -> /workspace/web/bin/Release/net8.0/{rid}/web.dll" }
+                &format! {"web -> /tmp/build_artifacts/bin/web/release_{rid}/web.dll" }
             );
             assert_contains!(context.pack_stdout, "web -> /workspace/web/bin/publish/");
         },
@@ -76,7 +76,7 @@ fn test_dotnet_publish_with_debug_configuration() {
                   MSBuild version 17.8.3+195e7f5a3 for .NET
                           Determining projects to restore...
                           Restored /workspace/foo.csproj <PLACEHOLDER>.
-                          foo -> /workspace/bin/Debug/net8.0/{rid}/foo.dll
+                          foo -> /tmp/build_artifacts/bin/foo/debug_{rid}/foo.dll
                           foo -> /workspace/bin/publish/"}
             );
         },
@@ -156,7 +156,7 @@ fn test_dotnet_publish_with_global_json_and_custom_verbosity_level() {
               &formatdoc! {r#"
                 - Publish solution
                   - Using `Release` build configuration
-                  - Running `dotnet publish /workspace/foo.csproj --runtime {rid} "-p:PublishDir=bin/publish" --verbosity normal`
+                  - Running `dotnet publish /workspace/foo.csproj --runtime {rid} "-p:PublishDir=bin/publish" --artifacts-path /tmp/build_artifacts --verbosity normal`
                 
                       MSBuild version 17.8.3+195e7f5a3 for .NET
                       Build started <PLACEHOLDER>.


### PR DESCRIPTION
We currently don't do anything to clean up intermediate build artifacts following a build. However, running dotnet publish produces several unused build artifacts that are copied/duplicated to the bin/publish folders users will use.

In many cases this has a relatively small impact on the output footprint. However, the impact can be quite significant in certain cases -- especially when the source includes large files that are copied to the output directory, or when compiling self-contained and/or AOT apps.

Fixes https://github.com/heroku/buildpacks-dotnet/issues/192