### PR TITLE
Prefer custom GHA arm runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: ["amd64", "arm64"]
-    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-medium' || 'ubuntu-24.04' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
GitHub's public arm runners are currently a bit flaky (see https://github.com/rust-lang/rust/issues/135867#issuecomment-2611121573). This reverts commit ebd58ce3a239342a730cf2c663bf0bc8521ff597.