### PR TITLE
Restore dotnet tools

### DIFF
--- a/buildpacks/dotnet/CHANGELOG.md
+++ b/buildpacks/dotnet/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The buildpack will now restore .NET tools when a tool manifest file is detected. ([#194](https://github.com/heroku/buildpacks-dotnet/pull/194))
+
 ## [0.2.1] - 2025-02-12
 
 ### Changed

--- a/buildpacks/dotnet/src/detect.rs
+++ b/buildpacks/dotnet/src/detect.rs
@@ -29,12 +29,13 @@ pub(crate) fn get_files_with_extensions(
 
 /// Returns the path to `global.json` if it exists in the given directory.
 pub(crate) fn global_json_file<P: AsRef<Path>>(dir: P) -> Option<PathBuf> {
+    let filename = "global.json";
     let dir = dir.as_ref();
     if !dir.is_dir() {
         return None;
     }
 
-    let global_json_path = dir.join("global.json");
+    let global_json_path = dir.join(filename);
     if global_json_path.exists() && global_json_path.is_file() {
         Some(global_json_path)
     } else {

--- a/buildpacks/dotnet/src/detect.rs
+++ b/buildpacks/dotnet/src/detect.rs
@@ -29,15 +29,18 @@ pub(crate) fn get_files_with_extensions(
 
 /// Returns the path to `global.json` if it exists in the given directory.
 pub(crate) fn global_json_file<P: AsRef<Path>>(dir: P) -> Option<PathBuf> {
-    let path = Path::new("global.json");
+    config_file(dir, "global.json")
+}
+
+fn config_file<P: AsRef<Path>, F: AsRef<Path>>(dir: P, path: F) -> Option<PathBuf> {
     let dir = dir.as_ref();
     if !dir.is_dir() {
         return None;
     }
 
-    let global_json_path = dir.join(path);
-    if global_json_path.exists() && global_json_path.is_file() {
-        Some(global_json_path)
+    let config_path = dir.join(path);
+    if config_path.exists() && config_path.is_file() {
+        Some(config_path)
     } else {
         None
     }

--- a/buildpacks/dotnet/src/detect.rs
+++ b/buildpacks/dotnet/src/detect.rs
@@ -29,16 +29,13 @@ pub(crate) fn get_files_with_extensions(
 
 /// Returns the path to `global.json` if it exists in the given directory.
 pub(crate) fn global_json_file<P: AsRef<Path>>(dir: P) -> Option<PathBuf> {
-    config_file(dir, "global.json")
+    let path = dir.as_ref().join("global.json");
+    path.is_file().then_some(path)
 }
 
 /// Returns the path to `.config/dotnet-tools.json` if it exists.
 pub(crate) fn dotnet_tools_file<P: AsRef<Path>>(dir: P) -> Option<PathBuf> {
-    config_file(dir, ".config/dotnet-tools.json")
-}
-
-fn config_file<P: AsRef<Path>, F: AsRef<Path>>(dir: P, filename: F) -> Option<PathBuf> {
-    let path = dir.as_ref().join(filename);
+    let path = dir.as_ref().join(".config/dotnet-tools.json");
     path.is_file().then_some(path)
 }
 

--- a/buildpacks/dotnet/src/detect.rs
+++ b/buildpacks/dotnet/src/detect.rs
@@ -32,6 +32,11 @@ pub(crate) fn global_json_file<P: AsRef<Path>>(dir: P) -> Option<PathBuf> {
     config_file(dir, "global.json")
 }
 
+/// Returns the path to `.config/dotnet-tools.json` if it exists.
+pub(crate) fn dotnet_tools_file<P: AsRef<Path>>(dir: P) -> Option<PathBuf> {
+    config_file(dir, ".config/dotnet-tools.json")
+}
+
 fn config_file<P: AsRef<Path>, F: AsRef<Path>>(dir: P, filename: F) -> Option<PathBuf> {
     let path = dir.as_ref().join(filename);
     path.is_file().then_some(path)
@@ -40,7 +45,7 @@ fn config_file<P: AsRef<Path>, F: AsRef<Path>>(dir: P, filename: F) -> Option<Pa
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::File;
+    use std::fs::{create_dir, File};
     use tempfile::TempDir;
 
     #[test]
@@ -87,6 +92,26 @@ mod tests {
     fn test_global_json_file_does_not_exist() {
         let temp_dir = TempDir::new().unwrap();
         let result = global_json_file(temp_dir.path());
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_dotnet_tools_file_exists() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_dir = temp_dir.path().join(".config");
+        create_dir(&config_dir).unwrap();
+
+        let dotnet_tools_path = config_dir.join("dotnet-tools.json");
+        File::create(&dotnet_tools_path).unwrap();
+
+        let result = dotnet_tools_file(temp_dir.path());
+        assert_eq!(result, Some(dotnet_tools_path));
+    }
+
+    #[test]
+    fn test_dotnet_tools_file_does_not_exist() {
+        let temp_dir = TempDir::new().unwrap();
+        let result = dotnet_tools_file(temp_dir.path());
         assert_eq!(result, None);
     }
 

--- a/buildpacks/dotnet/src/detect.rs
+++ b/buildpacks/dotnet/src/detect.rs
@@ -34,7 +34,7 @@ pub(crate) fn global_json_file<P: AsRef<Path>>(dir: P) -> Option<PathBuf> {
 }
 
 /// Returns the path to `.config/dotnet-tools.json` if it exists.
-pub(crate) fn dotnet_tools_file<P: AsRef<Path>>(dir: P) -> Option<PathBuf> {
+pub(crate) fn dotnet_tools_manifest_file<P: AsRef<Path>>(dir: P) -> Option<PathBuf> {
     let path = dir.as_ref().join(".config/dotnet-tools.json");
     path.is_file().then_some(path)
 }
@@ -93,7 +93,7 @@ mod tests {
     }
 
     #[test]
-    fn test_dotnet_tools_file_exists() {
+    fn test_dotnet_tools_manifest_file_exists() {
         let temp_dir = TempDir::new().unwrap();
         let config_dir = temp_dir.path().join(".config");
         create_dir(&config_dir).unwrap();
@@ -101,14 +101,14 @@ mod tests {
         let dotnet_tools_path = config_dir.join("dotnet-tools.json");
         File::create(&dotnet_tools_path).unwrap();
 
-        let result = dotnet_tools_file(temp_dir.path());
+        let result = dotnet_tools_manifest_file(temp_dir.path());
         assert_eq!(result, Some(dotnet_tools_path));
     }
 
     #[test]
-    fn test_dotnet_tools_file_does_not_exist() {
+    fn test_dotnet_tools_manifest_file_does_not_exist() {
         let temp_dir = TempDir::new().unwrap();
-        let result = dotnet_tools_file(temp_dir.path());
+        let result = dotnet_tools_manifest_file(temp_dir.path());
         assert_eq!(result, None);
     }
 

--- a/buildpacks/dotnet/src/detect.rs
+++ b/buildpacks/dotnet/src/detect.rs
@@ -32,18 +32,9 @@ pub(crate) fn global_json_file<P: AsRef<Path>>(dir: P) -> Option<PathBuf> {
     config_file(dir, "global.json")
 }
 
-fn config_file<P: AsRef<Path>, F: AsRef<Path>>(dir: P, path: F) -> Option<PathBuf> {
-    let dir = dir.as_ref();
-    if !dir.is_dir() {
-        return None;
-    }
-
-    let config_path = dir.join(path);
-    if config_path.exists() && config_path.is_file() {
-        Some(config_path)
-    } else {
-        None
-    }
+fn config_file<P: AsRef<Path>, F: AsRef<Path>>(dir: P, filename: F) -> Option<PathBuf> {
+    let path = dir.as_ref().join(filename);
+    path.is_file().then_some(path)
 }
 
 #[cfg(test)]

--- a/buildpacks/dotnet/src/detect.rs
+++ b/buildpacks/dotnet/src/detect.rs
@@ -29,13 +29,13 @@ pub(crate) fn get_files_with_extensions(
 
 /// Returns the path to `global.json` if it exists in the given directory.
 pub(crate) fn global_json_file<P: AsRef<Path>>(dir: P) -> Option<PathBuf> {
-    let filename = "global.json";
+    let path = Path::new("global.json");
     let dir = dir.as_ref();
     if !dir.is_dir() {
         return None;
     }
 
-    let global_json_path = dir.join(filename);
+    let global_json_path = dir.join(path);
     if global_json_path.exists() && global_json_path.is_file() {
         Some(global_json_path)
     } else {

--- a/buildpacks/dotnet/src/errors.rs
+++ b/buildpacks/dotnet/src/errors.rs
@@ -231,6 +231,30 @@ fn on_buildpack_error(error: &DotnetBuildpackError) {
                 );
             }
         },
+        DotnetBuildpackError::RestoreDotnetToolsCommand(error) => match error {
+            fun_run::CmdError::SystemError(_message, io_error) => log_io_error(
+                "Unable to restore .NET tools",
+                "running the command to restore .NET tools",
+                io_error,
+            ),
+            fun_run::CmdError::NonZeroExitNotStreamed(output)
+            | fun_run::CmdError::NonZeroExitAlreadyStreamed(output) => log_error(
+                "Unable to restore .NET tools",
+                formatdoc! {"
+                    The `dotnet tool restore` command exited unsuccessfully ({exit_status}).
+
+                    This error usually happens due to configuration errors. Use the command output
+                    above to troubleshoot and retry your build.
+
+                    The .NET tool restore command can also fail for a number of other reasons, such
+                    as intermittent network issues, unavailability of the NuGet package feed and/or
+                    other external dependencies, etc.
+
+                    Try again to see if the error resolves itself.
+                ", exit_status = output.status()},
+                None,
+            ),
+        },
         DotnetBuildpackError::PublishCommand(error) => match error {
             fun_run::CmdError::SystemError(_message, io_error) => log_io_error(
                 "Unable to publish",

--- a/buildpacks/dotnet/src/errors.rs
+++ b/buildpacks/dotnet/src/errors.rs
@@ -246,8 +246,8 @@ fn on_buildpack_error(error: &DotnetBuildpackError) {
                     This error usually happens due to configuration errors. Use the command output
                     above to troubleshoot and retry your build.
 
-                    The .NET tool restore command can also fail for a number of other reasons, such
-                    as intermittent network issues, unavailability of the NuGet package feed and/or
+                    Restoring .NET tools can also fail for a number of other reasons, such as
+                    intermittent network issues, unavailability of the NuGet package feed and/or
                     other external dependencies, etc.
 
                     Try again to see if the error resolves itself.

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -127,14 +127,14 @@ impl Buildpack for DotnetBuildpack {
             nuget_cache_layer.path(),
         );
 
-        if let Some(dotnet_tools_path) = detect::dotnet_tools_file(&context.app_dir) {
+        if let Some(manifest_path) = detect::dotnet_tools_manifest_file(&context.app_dir) {
             let mut restore_tools_command = Command::new("dotnet");
             restore_tools_command
                 .args([
                     "tool",
                     "restore",
                     "--tool-manifest",
-                    &dotnet_tools_path.to_string_lossy(),
+                    &manifest_path.to_string_lossy(),
                 ])
                 .current_dir(&context.app_dir)
                 .envs(&command_env.apply(Scope::Build, &Env::from_current()));

--- a/buildpacks/dotnet/tests/dotnet_restore_tools_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_restore_tools_test.rs
@@ -52,8 +52,8 @@ fn test_dotnet_restore_dotnet_tool_with_configuration_error() {
                     ! This error usually happens due to configuration errors. Use the command output
                     ! above to troubleshoot and retry your build.
                     !
-                    ! The .NET tool restore command can also fail for a number of other reasons, such
-                    ! as intermittent network issues, unavailability of the NuGet package feed and/or
+                    ! Restoring .NET tools can also fail for a number of other reasons, such as
+                    ! intermittent network issues, unavailability of the NuGet package feed and/or
                     ! other external dependencies, etc.
                     !
                     ! Try again to see if the error resolves itself."}

--- a/buildpacks/dotnet/tests/dotnet_restore_tools_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_restore_tools_test.rs
@@ -1,0 +1,63 @@
+use crate::tests::default_build_config;
+use indoc::indoc;
+use libcnb_test::{assert_contains, assert_empty, PackResult, TestRunner};
+
+#[test]
+#[ignore = "integration test"]
+fn test_dotnet_restore_and_run_dotnet_tool() {
+    TestRunner::default().build(
+        default_build_config("tests/fixtures/console_with_dotnet_tool"),
+        |context| {
+            assert_empty!(context.pack_stderr);
+            assert_contains!(
+                &context.pack_stdout,
+                indoc! { r"
+                    - Restore .NET tools
+                      - Tool manifest file detected
+                      - Running `dotnet tool restore --tool-manifest /workspace/.config/dotnet-tools.json`
+
+                          Tool 'dotnetsay' (version '2.1.7') was restored. Available commands: dotnetsay
+
+                          Restore was successful."}
+            );
+            assert_contains!(&context.pack_stdout, "Running dotnetsay post-publish");
+            assert_contains!(&context.pack_stdout, "__________________");
+        },
+    );
+}
+
+#[test]
+#[ignore = "integration test"]
+fn test_dotnet_restore_dotnet_tool_with_configuration_error() {
+    TestRunner::default().build(
+        default_build_config("tests/fixtures/console_with_dotnet_tool_configuration_error")
+            .expected_pack_result(PackResult::Failure),
+        |context| {
+            assert_contains!(
+                &context.pack_stdout,
+                indoc! { r"
+                    - Restore .NET tools
+                      - Tool manifest file detected
+                      - Running `dotnet tool restore --tool-manifest /workspace/.config/dotnet-tools.json`
+
+                          Version 0.0.0-foobar of package dotnetsay is not found in NuGet feeds https://api.nuget.org/v3/index.json."}
+            );
+            assert_contains!(
+                &context.pack_stderr,
+                &indoc! {r"
+                    ! Unable to restore .NET tools
+                    !
+                    ! The `dotnet tool restore` command exited unsuccessfully (exit status: 1).
+                    !
+                    ! This error usually happens due to configuration errors. Use the command output
+                    ! above to troubleshoot and retry your build.
+                    !
+                    ! The .NET tool restore command can also fail for a number of other reasons, such
+                    ! as intermittent network issues, unavailability of the NuGet package feed and/or
+                    ! other external dependencies, etc.
+                    !
+                    ! Try again to see if the error resolves itself."}
+            );
+        },
+    );
+}

--- a/buildpacks/dotnet/tests/fixtures/console_with_dotnet_tool/.config/dotnet-tools.json
+++ b/buildpacks/dotnet/tests/fixtures/console_with_dotnet_tool/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnetsay": {
+      "version": "2.1.7",
+      "commands": [
+        "dotnetsay"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/buildpacks/dotnet/tests/fixtures/console_with_dotnet_tool/Program.cs
+++ b/buildpacks/dotnet/tests/fixtures/console_with_dotnet_tool/Program.cs
@@ -1,0 +1,1 @@
+﻿Console.WriteLine("Hello, World!");

--- a/buildpacks/dotnet/tests/fixtures/console_with_dotnet_tool/consoleapp.csproj
+++ b/buildpacks/dotnet/tests/fixtures/console_with_dotnet_tool/consoleapp.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <Target Name="PostPublishStep" AfterTargets="Publish">
+    <Message Text="Running dotnetsay post-publish" Importance="High" />
+    <Exec Command="dotnet tool run dotnetsay" />
+  </Target>
+
+</Project>

--- a/buildpacks/dotnet/tests/fixtures/console_with_dotnet_tool_configuration_error/.config/dotnet-tools.json
+++ b/buildpacks/dotnet/tests/fixtures/console_with_dotnet_tool_configuration_error/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnetsay": {
+      "version": "0.0.0-foobar",
+      "commands": [
+        "dotnetsay"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/buildpacks/dotnet/tests/fixtures/console_with_dotnet_tool_configuration_error/Program.cs
+++ b/buildpacks/dotnet/tests/fixtures/console_with_dotnet_tool_configuration_error/Program.cs
@@ -1,0 +1,1 @@
+﻿Console.WriteLine("Hello, World!");

--- a/buildpacks/dotnet/tests/fixtures/console_with_dotnet_tool_configuration_error/consoleapp.csproj
+++ b/buildpacks/dotnet/tests/fixtures/console_with_dotnet_tool_configuration_error/consoleapp.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  
+</Project>

--- a/buildpacks/dotnet/tests/mod.rs
+++ b/buildpacks/dotnet/tests/mod.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 mod detect_test;
 mod dotnet_publish_test;
+mod dotnet_restore_tools_test;
 mod nuget_layer_test;
 mod sdk_installation_test;
 


### PR DESCRIPTION
This PR adds support for restoring [.NET tools](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-restore) during the build process.

Currently, this support only includes restoring:
* Local tools which are only available during the build process.
* Tools defined in the `{app_root}/.config/dotnet-tools.json` manifest file. Manifests in other locations (e.g. project folders) are not restored.

.NET tools can be used for many things -- for instance, the [`dotnet-ef` tool](https://learn.microsoft.com/en-us/ef/core/cli/dotnet) is commonly used to bundle database migrations (including [in our Getting Started app](https://github.com/heroku/dotnet-getting-started/blob/b720e9964b8a9e08a2eed040590ab134d32644d1/Frontend/Frontend.csproj#L25-L28)).

Automatically detecting and restoring such tools during the build process reduces the amount of configuration needed to execute those workloads.