### PR TITLE
Verify .NET runtime dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        builder: ["builder:24", "builder:22"]
         arch: ["amd64", "arm64"]
+        exclude:
+          - builder: "builder:22"
+            arch: "arm64"
     runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-medium' || 'ubuntu-24.04' }}
+    env:
+      INTEGRATION_TEST_BUILDER: heroku/${{ matrix.builder }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -73,9 +79,16 @@ jobs:
         uses: buildpacks/github-actions/setup-pack@c502bcff683efa6f6d56a325df3fbe1722e21881 # v5.8.11
       # The images are pulled up front to prevent duplicate pulls due to the tests being run concurrently.
       - name: Pull builder image
-        run: docker pull heroku/builder:24
+        run: docker pull '${{ env.INTEGRATION_TEST_BUILDER }}'
       - name: Pull run image
-        run: docker pull heroku/heroku:24
+        # Using `docker inspect` rather than `pack builder inspect` since the latter makes
+        # additional requests to Docker Hub even when the image is available locally.
+        run: |
+          RUN_IMAGE=$(
+            docker inspect --format='{{index .Config.Labels "io.buildpacks.builder.metadata"}}' '${{ env.INTEGRATION_TEST_BUILDER }}' \
+              | jq --exit-status --raw-output '.stack.runImage.image'
+          )
+          docker pull "${RUN_IMAGE}"
       # The integration tests are annotated with the `ignore` attribute, allowing us to run
       # only those and not the unit tests, via the `--ignored` option. On the latest stack
       # we run all integration tests, but on older stacks we only run stack-specific tests.

--- a/buildpacks/dotnet/tests/mod.rs
+++ b/buildpacks/dotnet/tests/mod.rs
@@ -5,6 +5,7 @@ mod detect_test;
 mod dotnet_publish_test;
 mod dotnet_restore_tools_test;
 mod nuget_layer_test;
+mod runtime_dependencies_test;
 mod sdk_installation_test;
 mod test_execution_environment_test;
 

--- a/buildpacks/dotnet/tests/mod.rs
+++ b/buildpacks/dotnet/tests/mod.rs
@@ -1,4 +1,5 @@
 use libcnb_test::BuildConfig;
+use std::env;
 use std::path::Path;
 
 mod detect_test;
@@ -9,13 +10,19 @@ mod runtime_dependencies_test;
 mod sdk_installation_test;
 mod test_execution_environment_test;
 
-pub(crate) fn default_build_config(fixture_path: impl AsRef<Path>) -> BuildConfig {
-    #[cfg(target_arch = "x86_64")]
-    let target_triple = "x86_64-unknown-linux-musl";
-    #[cfg(target_arch = "aarch64")]
-    let target_triple = "aarch64-unknown-linux-musl";
+const DEFAULT_BUILDER: &str = "heroku/builder:24";
 
-    let mut config = BuildConfig::new("heroku/builder:24", fixture_path);
+pub(crate) fn default_build_config(fixture_path: impl AsRef<Path>) -> BuildConfig {
+    let builder = builder();
+    let mut config = BuildConfig::new(&builder, fixture_path);
+
+    // TODO: Once Pack build supports `--platform` and libcnb-test adjusted accordingly, change this
+    // to allow configuring the target arch independently of the builder name (eg via env var).
+    let target_triple = match builder.as_str() {
+        // Compile the buildpack for ARM64 if the builder supports multi-arch and the host is ARM64.
+        "heroku/builder:24" if cfg!(target_arch = "aarch64") => "aarch64-unknown-linux-musl",
+        _ => "x86_64-unknown-linux-musl",
+    };
     config.target_triple(target_triple);
     config
 }
@@ -27,4 +34,8 @@ fn get_dotnet_arch() -> String {
     let arch = "arm64";
 
     arch.to_string()
+}
+
+fn builder() -> String {
+    env::var("INTEGRATION_TEST_BUILDER").unwrap_or(DEFAULT_BUILDER.to_string())
 }

--- a/buildpacks/dotnet/tests/runtime_dependencies_test.rs
+++ b/buildpacks/dotnet/tests/runtime_dependencies_test.rs
@@ -1,0 +1,74 @@
+use crate::tests::default_build_config;
+use indoc::indoc;
+use libcnb_test::{TestRunner, assert_contains, assert_empty};
+
+#[test]
+#[ignore = "integration test"]
+fn verify_installed_dotnet_runtime_dependencies() {
+    TestRunner::default().build(
+        default_build_config("tests/fixtures/class_library"),
+        |context| {
+        let command_output = context.run_shell_command(
+            indoc! {r#"
+                set -euo pipefail
+
+                echo "Checking required .NET dependencies..."
+
+                OS_VERSION=$(lsb_release -rs)
+
+                # Define common dependencies (for both Ubuntu 22.04 and 24.04)
+                COMMON_DEPENDENCIES=(
+                    "ca-certificates"
+                    "libc6"
+                    "libgcc-s1"
+                    "libstdc++6"
+                    "libunwind8"
+                    "zlib1g"
+                )
+
+                # Define version-specific dependencies
+                if [[ "$OS_VERSION" == "22.04" ]]; then
+                    VERSION_SPECIFIC_DEPENDENCIES=(
+                        "libgssapi-krb5-2"
+                        "libicu70"
+                        "liblttng-ust1"
+                        "libssl3"
+                    )
+                elif [[ "$OS_VERSION" == "24.04" ]]; then
+                    VERSION_SPECIFIC_DEPENDENCIES=(
+                        "libicu74"
+                        "liblttng-ust1t64"
+                        "libssl3t64"
+                    )
+                else
+                    echo "Unsupported Ubuntu version: ${OS_VERSION}. This script is designed for Ubuntu 22.04 and 24.04."
+                    exit 1
+                fi
+
+                DEPENDENCIES=("${COMMON_DEPENDENCIES[@]}" "${VERSION_SPECIFIC_DEPENDENCIES[@]}")
+                MISSING_PACKAGES=()
+
+                for PACKAGE in "${DEPENDENCIES[@]}"; do
+                    if ! dpkg -s "$PACKAGE" &> /dev/null; then
+                        MISSING_PACKAGES+=("$PACKAGE")
+                    fi
+                done
+
+                if [ ${#MISSING_PACKAGES[@]} -eq 0 ]; then
+                    echo "All required .NET dependencies are installed."
+                    exit 0
+                else
+                    echo "Missing dependencies:"
+                    for PACKAGE in "${MISSING_PACKAGES[@]}"; do
+                        echo "   - $PACKAGE"
+                    done
+                    exit 1
+                fi
+            "#}
+        );
+        assert_empty!(command_output.stderr);
+        assert_contains!(
+            command_output.stdout, "All required .NET dependencies are installed");
+        },
+    );
+}

--- a/buildpacks/dotnet/tests/runtime_dependencies_test.rs
+++ b/buildpacks/dotnet/tests/runtime_dependencies_test.rs
@@ -17,12 +17,14 @@ fn verify_installed_dotnet_runtime_dependencies() {
                 if grep 'not found' <<<"${ldd_output}" | sort --unique; then
                     echo "The above dynamically linked libraries were not found!"
                     exit 1
+                else
+                    echo "All dynamically linked libraries were found."
                 fi
             "#}
         );
         assert_empty!(command_output.stderr);
         assert_contains!(
-            command_output.stdout, "All required .NET dependencies are installed");
+            command_output.stdout, "All dynamically linked libraries were found.");
         },
     );
 }

--- a/buildpacks/dotnet/tests/runtime_dependencies_test.rs
+++ b/buildpacks/dotnet/tests/runtime_dependencies_test.rs
@@ -12,7 +12,7 @@ fn verify_installed_dotnet_runtime_dependencies() {
             indoc! {r#"
                 set -euo pipefail
                 
-                # Check all required dynamically linked libraries can be found in the run image.
+                # Check that all required dynamically linked libraries can be found in the run image.
 
                 # Capture ldd output for `dotnet` executables and `*.so*` shared libraries in `/layers`.
                 ldd_output=$(find /layers -type f,l \( -name 'dotnet' -o -name '*.so*' \) -exec ldd '{}' +)

--- a/buildpacks/dotnet/tests/runtime_dependencies_test.rs
+++ b/buildpacks/dotnet/tests/runtime_dependencies_test.rs
@@ -13,8 +13,15 @@ fn verify_installed_dotnet_runtime_dependencies() {
                 set -euo pipefail
                 
                 # Check all required dynamically linked libraries can be found in the run image.
+
+                # Capture ldd output for `dotnet` executables and `*.so*` shared libraries in `/layers`.
                 ldd_output=$(find /layers -type f,l \( -name 'dotnet' -o -name '*.so*' \) -exec ldd '{}' +)
-                if grep 'not found' <<<"${ldd_output}" | sort --unique; then
+
+                # Check for missing libraries.
+                # An exception is made for `liblttng-ust.so.0`, which is filtered out as it is considered
+                # non-critical, and expected to be missing in some environments.
+                # For more info, see: https://github.com/heroku/base-images/pull/346#issuecomment-2715075259
+                if grep 'not found' <<<"${ldd_output}" | grep -v 'liblttng-ust.so.0' | sort --unique; then
                     echo "The above dynamically linked libraries were not found!"
                     exit 1
                 else

--- a/buildpacks/dotnet/tests/runtime_dependencies_test.rs
+++ b/buildpacks/dotnet/tests/runtime_dependencies_test.rs
@@ -11,57 +11,11 @@ fn verify_installed_dotnet_runtime_dependencies() {
         let command_output = context.run_shell_command(
             indoc! {r#"
                 set -euo pipefail
-
-                echo "Checking required .NET dependencies..."
-
-                OS_VERSION=$(lsb_release -rs)
-
-                # Define common dependencies (for both Ubuntu 22.04 and 24.04)
-                COMMON_DEPENDENCIES=(
-                    "ca-certificates"
-                    "libc6"
-                    "libgcc-s1"
-                    "libstdc++6"
-                    "libunwind8"
-                    "zlib1g"
-                )
-
-                # Define version-specific dependencies
-                if [[ "$OS_VERSION" == "22.04" ]]; then
-                    VERSION_SPECIFIC_DEPENDENCIES=(
-                        "libgssapi-krb5-2"
-                        "libicu70"
-                        "liblttng-ust1"
-                        "libssl3"
-                    )
-                elif [[ "$OS_VERSION" == "24.04" ]]; then
-                    VERSION_SPECIFIC_DEPENDENCIES=(
-                        "libicu74"
-                        "liblttng-ust1t64"
-                        "libssl3t64"
-                    )
-                else
-                    echo "Unsupported Ubuntu version: ${OS_VERSION}. This script is designed for Ubuntu 22.04 and 24.04."
-                    exit 1
-                fi
-
-                DEPENDENCIES=("${COMMON_DEPENDENCIES[@]}" "${VERSION_SPECIFIC_DEPENDENCIES[@]}")
-                MISSING_PACKAGES=()
-
-                for PACKAGE in "${DEPENDENCIES[@]}"; do
-                    if ! dpkg -s "$PACKAGE" &> /dev/null; then
-                        MISSING_PACKAGES+=("$PACKAGE")
-                    fi
-                done
-
-                if [ ${#MISSING_PACKAGES[@]} -eq 0 ]; then
-                    echo "All required .NET dependencies are installed."
-                    exit 0
-                else
-                    echo "Missing dependencies:"
-                    for PACKAGE in "${MISSING_PACKAGES[@]}"; do
-                        echo "   - $PACKAGE"
-                    done
+                
+                # Check all required dynamically linked libraries can be found in the run image.
+                ldd_output=$(find /layers -type f,l \( -name 'dotnet' -o -name '*.so*' \) -exec ldd '{}' +)
+                if grep 'not found' <<<"${ldd_output}" | sort --unique; then
+                    echo "The above dynamically linked libraries were not found!"
                     exit 1
                 fi
             "#}


### PR DESCRIPTION
This PR:

* Adds a check verifying that required dynamically linked libraries are available in the run image.
* Changes the CI configuration so integration tests run on `heroku/builder:22` (`amd64`) as well.

Also see https://github.com/heroku/base-images/pull/346#issuecomment-2715075259