### PR TITLE
Migrate to ureq v3 API

### DIFF
--- a/shared/inventory-updater/src/main.rs
+++ b/shared/inventory-updater/src/main.rs
@@ -132,7 +132,8 @@ fn list_upstream_artifacts() -> Vec<Artifact<Version, Sha512, Option<()>>> {
             ureq::get(&format!("https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/{major_version}.0/releases.json"))
                 .call()
                 .expect(".NET release feed should be available")
-                .into_json::<DotNetReleaseFeed>()
+                .body_mut()
+                .read_json::<DotNetReleaseFeed>()
                 .expect(".NET release feed should be parsable from JSON")
                 .releases
                 .into_iter()


### PR DESCRIPTION
`ureq` v3 introduced a breaking change that wasn't caught by our CI when [dependabot bumped the version](https://github.com/heroku/buildpacks-dotnet/pull/209) (more details here https://github.com/heroku/buildpacks-dotnet/pull/210).

This PR fixes the compilation error by updating how `inventory-updater` reads and parses `ureq` responses.

Also see https://github.com/algesten/ureq/issues/834#issuecomment-2403377769