### PR TITLE
Skip NuGet package XML doc extraction by default

### DIFF
--- a/buildpacks/dotnet/CHANGELOG.md
+++ b/buildpacks/dotnet/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The .NET SDK inventory was updated with new download URLs for version 9.0 release artifacts. ([#203](https://github.com/heroku/buildpacks-dotnet/pull/203))
+- The buildpack will now skip NuGet package XML doc extraction when running `dotnet publish`. ([#212](https://github.com/heroku/buildpacks-dotnet/pull/212))
 
 ## [0.3.0] - 2025-02-28
 

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -120,12 +120,20 @@ impl Buildpack for DotnetBuildpack {
         let sdk_layer = layers::sdk::handle(&context, sdk_artifact)?;
         let nuget_cache_layer = layers::nuget_cache::handle(&context)?;
 
-        let command_env = sdk_layer.read_env()?.chainable_insert(
-            Scope::Build,
-            libcnb::layer_env::ModificationBehavior::Override,
-            "NUGET_PACKAGES",
-            nuget_cache_layer.path(),
-        );
+        let command_env = sdk_layer
+            .read_env()?
+            .chainable_insert(
+                Scope::Build,
+                libcnb::layer_env::ModificationBehavior::Override,
+                "NUGET_PACKAGES",
+                nuget_cache_layer.path(),
+            )
+            .chainable_insert(
+                Scope::Build,
+                libcnb::layer_env::ModificationBehavior::Default,
+                "NUGET_XMLDOC_MODE",
+                "skip",
+            );
 
         if let Some(manifest_path) = detect::dotnet_tools_manifest_file(&context.app_dir) {
             let mut restore_tools_command = Command::new("dotnet");


### PR DESCRIPTION
This PR changes the NuGet package restore behavior to skip extracting XML documentation files by default. These files are typically not needed for non-interactive/CI build scenarios, but can add substantially to the NuGet cache layer size.

As an example, publishing the [.NET Getting Started app](https://github.com/heroku/dotnet-getting-started) (on an M1 Mac) adds ~813MB to the NuGet cache when XML docs are extracted (default), compared to ~570MB when skipped.

The environment variable is set as a default, respecting build-time environment configuration. Users may set `NUGET_XMLDOC_MODE` to `none`, `compress`, or `skip` [as documented here](https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-environment-variables).

This default should be documented in this [Dev Center article](https://devcenter.heroku.com/articles/dotnet-behavior-in-heroku#default-environment-variables) when released.