### PR TITLE
Drop default build configuration log output

### DIFF
--- a/buildpacks/dotnet/CHANGELOG.md
+++ b/buildpacks/dotnet/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The .NET SDK inventory was updated with new download URLs for version 9.0 release artifacts. ([#203](https://github.com/heroku/buildpacks-dotnet/pull/203))
 - The buildpack will now skip NuGet package XML doc extraction when running `dotnet publish`. ([#212](https://github.com/heroku/buildpacks-dotnet/pull/212))
+- The build configuration is no longer written to the log before the `dotnet publish` command (which still includes the build configuration value when specified). ([#213](https://github.com/heroku/buildpacks-dotnet/pull/213))
 
 ## [0.3.0] - 2025-02-28
 

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -157,14 +157,6 @@ impl Buildpack for DotnetBuildpack {
         }
 
         print::bullet("Publish solution");
-        let build_configuration = buildpack_configuration
-            .build_configuration
-            .clone()
-            .unwrap_or_else(|| String::from("Release"));
-        print::sub_bullet(format!(
-            "Using {} build configuration",
-            style::value(build_configuration.clone())
-        ));
 
         let mut publish_command = Command::from(DotnetPublishCommand {
             path: solution.path.clone(),

--- a/buildpacks/dotnet/tests/dotnet_publish_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_publish_test.rs
@@ -155,7 +155,6 @@ fn test_dotnet_publish_with_global_json_and_custom_verbosity_level() {
               replace_msbuild_log_patterns_with_placeholder(&context.pack_stdout, "<PLACEHOLDER>"), 
               &formatdoc! {r#"
                 - Publish solution
-                  - Using `Release` build configuration
                   - Running `dotnet publish /workspace/foo.csproj --runtime {rid} "-p:PublishDir=bin/publish" --artifacts-path /tmp/build_artifacts --verbosity normal`
                 
                       MSBuild version 17.8.3+195e7f5a3 for .NET

--- a/buildpacks/dotnet/tests/dotnet_publish_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_publish_test.rs
@@ -68,6 +68,11 @@ fn test_dotnet_publish_with_debug_configuration() {
 
             let rid = get_rid();
             assert_contains!(
+                &context.pack_stdout,
+                &formatdoc! {r#"
+                    - Running `dotnet publish /workspace/foo.csproj --runtime {rid} "-p:PublishDir=bin/publish" --artifacts-path /tmp/build_artifacts --configuration Debug`"#}
+            );
+            assert_contains!(
                 replace_msbuild_log_patterns_with_placeholder(
                     &context.pack_stdout,
                     "<PLACEHOLDER>"


### PR DESCRIPTION
When the (MS)build configuration is specified (using the `BUILD_CONFIGURATION` environment variable) it'll be evident from the command line, which is already printed to the buildpack output.

When unspecified, the build configuration value is excluded from the executed command, and the user can safely assume it's the default value for `dotnet publish` and consistent with the local behavior.

This change was cherry-picked from https://github.com/heroku/buildpacks-dotnet/pull/204/commits/ce4c928a0b22c803b559c53631b7df4008bfdcd2.