### PR TITLE
Refactor NuGet layer handling

### DIFF
--- a/buildpacks/dotnet/CHANGELOG.md
+++ b/buildpacks/dotnet/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The NuGet cache layer is now a build layer and available for later buildpacks. ([#221](https://github.com/heroku/buildpacks-dotnet/pull/221))
+
 ## [0.3.2] - 2025-03-11
 
 ### Added

--- a/buildpacks/dotnet/src/layers/nuget_cache.rs
+++ b/buildpacks/dotnet/src/layers/nuget_cache.rs
@@ -18,12 +18,13 @@ const MAX_NUGET_CACHE_RESTORE_COUNT: f32 = 20.0;
 
 pub(crate) fn handle(
     context: &BuildContext<DotnetBuildpack>,
+    available_at_launch: bool,
 ) -> Result<LayerRef<DotnetBuildpack, (), f32>, libcnb::Error<DotnetBuildpackError>> {
     let nuget_cache_layer = context.cached_layer(
         layer_name!("nuget-cache"),
         CachedLayerDefinition {
             build: true,
-            launch: false,
+            launch: available_at_launch,
             invalid_metadata_action: &|_| InvalidMetadataAction::DeleteLayer,
             restored_layer_action: &|metadata: &NugetCacheLayerMetadata, _path| {
                 if metadata.restore_count >= MAX_NUGET_CACHE_RESTORE_COUNT {

--- a/buildpacks/dotnet/src/layers/nuget_cache.rs
+++ b/buildpacks/dotnet/src/layers/nuget_cache.rs
@@ -6,6 +6,7 @@ use libcnb::layer::{
     CachedLayerDefinition, EmptyLayerCause, InvalidMetadataAction, LayerRef, LayerState,
     RestoredLayerAction,
 };
+use libcnb::layer_env::{LayerEnv, Scope};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
@@ -44,18 +45,37 @@ pub(crate) fn handle(
 
     if let Some(message) = match nuget_cache_layer.state {
         LayerState::Restored { .. } => Some("Reusing package cache".to_string()),
-        LayerState::Empty { cause } => match cause {
-            EmptyLayerCause::NewlyCreated => None,
-            EmptyLayerCause::InvalidMetadataAction { .. } => {
-                Some("Clearing package cache due to invalid metadata".to_string())
+        LayerState::Empty { cause } => {
+            nuget_cache_layer.write_env(
+                LayerEnv::new()
+                    .chainable_insert(
+                        Scope::Build,
+                        libcnb::layer_env::ModificationBehavior::Override,
+                        "NUGET_PACKAGES",
+                        nuget_cache_layer.path(),
+                    )
+                    .chainable_insert(
+                        Scope::Build,
+                        libcnb::layer_env::ModificationBehavior::Default,
+                        "NUGET_XMLDOC_MODE",
+                        "skip",
+                    ),
+            )?;
+
+            match cause {
+                EmptyLayerCause::NewlyCreated => None,
+                EmptyLayerCause::InvalidMetadataAction { .. } => {
+                    Some("Clearing package cache due to invalid metadata".to_string())
+                }
+                EmptyLayerCause::RestoredLayerAction { cause: count } => {
+                    Some(format!("Clearing package cache after {count} uses"))
+                }
             }
-            EmptyLayerCause::RestoredLayerAction { cause: count } => {
-                Some(format!("Clearing package cache after {count} uses"))
-            }
-        },
+        }
     } {
         print::bullet("NuGet cache");
         print::sub_bullet(message);
     }
+
     Ok(nuget_cache_layer)
 }

--- a/buildpacks/dotnet/src/layers/nuget_cache.rs
+++ b/buildpacks/dotnet/src/layers/nuget_cache.rs
@@ -22,7 +22,7 @@ pub(crate) fn handle(
     let nuget_cache_layer = context.cached_layer(
         layer_name!("nuget-cache"),
         CachedLayerDefinition {
-            build: false,
+            build: true,
             launch: false,
             invalid_metadata_action: &|_| InvalidMetadataAction::DeleteLayer,
             restored_layer_action: &|metadata: &NugetCacheLayerMetadata, _path| {

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -1,4 +1,4 @@
-use crate::{dotnet_layer_env, DotnetBuildpack, DotnetBuildpackError};
+use crate::{DotnetBuildpack, DotnetBuildpackError};
 use bullet_stream::global::print;
 use bullet_stream::style;
 use inventory::artifact::Artifact;
@@ -8,7 +8,6 @@ use libcnb::layer::{
     CachedLayerDefinition, EmptyLayerCause, InvalidMetadataAction, LayerRef, LayerState,
     RestoredLayerAction,
 };
-use libcnb::layer_env::Scope;
 use libherokubuildpack::download::{download_file, DownloadError};
 use libherokubuildpack::inventory;
 use libherokubuildpack::tar::decompress_tarball;
@@ -109,11 +108,6 @@ pub(crate) fn handle(
                 sdk_layer.path(),
             )
             .map_err(SdkLayerError::DecompressArchive)?;
-
-            sdk_layer.write_env(dotnet_layer_env::generate_layer_env(
-                sdk_layer.path().as_path(),
-                &Scope::Build,
-            ))?;
         }
     }
 

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -34,13 +34,14 @@ const MAX_RETRIES: u8 = 4;
 
 pub(crate) fn handle(
     context: &libcnb::build::BuildContext<DotnetBuildpack>,
+    available_at_launch: bool,
     artifact: &Artifact<Version, Sha512, Option<()>>,
 ) -> Result<LayerRef<DotnetBuildpack, (), CustomCause>, libcnb::Error<DotnetBuildpackError>> {
     let sdk_layer = context.cached_layer(
         layer_name!("sdk"),
         CachedLayerDefinition {
             build: true,
-            launch: false,
+            launch: available_at_launch,
             invalid_metadata_action: &|_| InvalidMetadataAction::DeleteLayer,
             restored_layer_action: &|metadata: &SdkLayerMetadata, _path| {
                 if metadata.artifact == *artifact {

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -118,6 +118,11 @@ impl Buildpack for DotnetBuildpack {
         ));
 
         let sdk_layer = layers::sdk::handle(&context, sdk_artifact)?;
+        sdk_layer.write_env(dotnet_layer_env::generate_layer_env(
+            sdk_layer.path().as_path(),
+            &Scope::Build,
+        ))?;
+
         let nuget_cache_layer = layers::nuget_cache::handle(&context)?;
 
         let command_env = nuget_cache_layer.read_env()?.apply(

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -117,23 +117,24 @@ impl Buildpack for DotnetBuildpack {
             style::details(format!("{}-{}", sdk_artifact.os, sdk_artifact.arch))
         ));
 
+        let sdk_scope = Scope::Build;
         let sdk_layer = layers::sdk::handle(&context, sdk_artifact)?;
         sdk_layer.write_env(dotnet_layer_env::generate_layer_env(
             sdk_layer.path().as_path(),
-            &Scope::Build,
+            &sdk_scope,
         ))?;
 
         let nuget_cache_layer = layers::nuget_cache::handle(&context)?;
         nuget_cache_layer.write_env(
             LayerEnv::new()
                 .chainable_insert(
-                    Scope::Build,
+                    sdk_scope.clone(),
                     libcnb::layer_env::ModificationBehavior::Override,
                     "NUGET_PACKAGES",
                     nuget_cache_layer.path(),
                 )
                 .chainable_insert(
-                    Scope::Build,
+                    sdk_scope.clone(),
                     libcnb::layer_env::ModificationBehavior::Default,
                     "NUGET_XMLDOC_MODE",
                     "skip",

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -126,7 +126,7 @@ impl Buildpack for DotnetBuildpack {
             &sdk_scope,
         ))?;
 
-        let nuget_cache_layer = layers::nuget_cache::handle(&context)?;
+        let nuget_cache_layer = layers::nuget_cache::handle(&context, sdk_available_at_launch)?;
         nuget_cache_layer.write_env(
             LayerEnv::new()
                 .chainable_insert(

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -133,7 +133,8 @@ impl Buildpack for DotnetBuildpack {
                 libcnb::layer_env::ModificationBehavior::Default,
                 "NUGET_XMLDOC_MODE",
                 "skip",
-            );
+            )
+            .apply(Scope::Build, &Env::from_current());
 
         if let Some(manifest_path) = detect::dotnet_tools_manifest_file(&context.app_dir) {
             let mut restore_tools_command = Command::new("dotnet");
@@ -145,7 +146,7 @@ impl Buildpack for DotnetBuildpack {
                     &manifest_path.to_string_lossy(),
                 ])
                 .current_dir(&context.app_dir)
-                .envs(&command_env.apply(Scope::Build, &Env::from_current()));
+                .envs(&command_env);
 
             print::bullet("Restore .NET tools");
             print::sub_bullet("Tool manifest file detected");
@@ -166,7 +167,7 @@ impl Buildpack for DotnetBuildpack {
         });
         publish_command
             .current_dir(&context.app_dir)
-            .envs(&command_env.apply(Scope::Build, &Env::from_current()));
+            .envs(&command_env);
 
         print::sub_stream_with(
             format!("Running {}", style::command(publish_command.name())),

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -29,7 +29,7 @@ use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::data::launch::LaunchBuilder;
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericMetadata, GenericPlatform};
-use libcnb::layer_env::Scope;
+use libcnb::layer_env::{LayerEnv, Scope};
 use libcnb::{buildpack_main, Buildpack, Env};
 use libherokubuildpack::inventory;
 use semver::{Version, VersionReq};
@@ -124,6 +124,21 @@ impl Buildpack for DotnetBuildpack {
         ))?;
 
         let nuget_cache_layer = layers::nuget_cache::handle(&context)?;
+        nuget_cache_layer.write_env(
+            LayerEnv::new()
+                .chainable_insert(
+                    Scope::Build,
+                    libcnb::layer_env::ModificationBehavior::Override,
+                    "NUGET_PACKAGES",
+                    nuget_cache_layer.path(),
+                )
+                .chainable_insert(
+                    Scope::Build,
+                    libcnb::layer_env::ModificationBehavior::Default,
+                    "NUGET_XMLDOC_MODE",
+                    "skip",
+                ),
+        )?;
 
         let command_env = nuget_cache_layer.read_env()?.apply(
             Scope::Build,

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -118,7 +118,9 @@ impl Buildpack for DotnetBuildpack {
         ));
 
         let sdk_scope = Scope::Build;
-        let sdk_layer = layers::sdk::handle(&context, sdk_artifact)?;
+        let sdk_available_at_launch = sdk_scope == Scope::Launch;
+
+        let sdk_layer = layers::sdk::handle(&context, sdk_available_at_launch, sdk_artifact)?;
         sdk_layer.write_env(dotnet_layer_env::generate_layer_env(
             sdk_layer.path().as_path(),
             &sdk_scope,

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -188,7 +188,9 @@ impl Buildpack for DotnetBuildpack {
             |stdout, stderr| publish_command.stream_output(stdout, stderr),
         )
         .map_err(DotnetBuildpackError::PublishCommand)?;
-        layers::runtime::handle(&context, &sdk_layer.path())?;
+        if !sdk_available_at_launch {
+            layers::runtime::handle(&context, &sdk_layer.path())?;
+        }
 
         print::bullet("Process types");
         print::sub_bullet("Detecting process types from published artifacts");

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -118,7 +118,7 @@ impl Buildpack for DotnetBuildpack {
         ));
 
         let sdk_scope = Scope::Build;
-        let sdk_available_at_launch = sdk_scope == Scope::Launch;
+        let sdk_available_at_launch = sdk_scope == Scope::Launch || sdk_scope == Scope::All;
 
         let sdk_layer = layers::sdk::handle(&context, sdk_available_at_launch, sdk_artifact)?;
         sdk_layer.write_env(dotnet_layer_env::generate_layer_env(

--- a/buildpacks/dotnet/tests/fixtures/testing_buildpack/bin/build
+++ b/buildpacks/dotnet/tests/fixtures/testing_buildpack/bin/build
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Check that:
+# - The correct env vars are set for later buildpacks.
+
+set -euo pipefail
+
+echo
+echo "## Testing buildpack ##"
+
+printenv | sort | grep -vE '^(_|CNB_.+|HOME|HOSTNAME|OLDPWD|PWD|SHLVL)='

--- a/buildpacks/dotnet/tests/fixtures/testing_buildpack/bin/detect
+++ b/buildpacks/dotnet/tests/fixtures/testing_buildpack/bin/detect
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exit 0

--- a/buildpacks/dotnet/tests/fixtures/testing_buildpack/buildpack.toml
+++ b/buildpacks/dotnet/tests/fixtures/testing_buildpack/buildpack.toml
@@ -1,0 +1,6 @@
+api = "0.11"
+
+[buildpack]
+id = "testing-buildpack"
+version = "0.0.0"
+clear-env = true

--- a/buildpacks/dotnet/tests/sdk_installation_test.rs
+++ b/buildpacks/dotnet/tests/sdk_installation_test.rs
@@ -81,6 +81,8 @@ fn test_sdk_basic_install_build_environment() {
                 DOTNET_NOLOGO=true
                 DOTNET_ROOT=/layers/heroku_dotnet/sdk
                 DOTNET_RUNNING_IN_CONTAINER=true
+                NUGET_PACKAGES=/layers/heroku_dotnet/nuget-cache
+                NUGET_XMLDOC_MODE=skip
                 PATH=/layers/heroku_dotnet/sdk:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
         );
     });

--- a/buildpacks/dotnet/tests/sdk_installation_test.rs
+++ b/buildpacks/dotnet/tests/sdk_installation_test.rs
@@ -1,6 +1,6 @@
 use crate::tests::default_build_config;
 use indoc::indoc;
-use libcnb_test::{assert_contains, assert_empty, TestRunner};
+use libcnb_test::{assert_contains, assert_empty, BuildpackReference, TestRunner};
 
 #[test]
 #[ignore = "integration test"]
@@ -59,6 +59,31 @@ fn test_sdk_resolution_with_solution_file() {
             );
         },
     );
+}
+
+#[test]
+#[ignore = "integration test"]
+fn test_sdk_basic_install_build_environment() {
+    let mut config = default_build_config("tests/fixtures/console_with_nuget_package");
+    config.buildpacks(vec![
+        BuildpackReference::CurrentCrate,
+        BuildpackReference::Other("file://tests/fixtures/testing_buildpack".to_string()),
+    ]);
+
+    TestRunner::default().build(&config, |context| {
+        assert_empty!(context.pack_stderr);
+        assert_contains!(
+            context.pack_stdout,
+            &indoc! {"
+                ## Testing buildpack ##
+                DOTNET_CLI_TELEMETRY_OPTOUT=true
+                DOTNET_EnableWriteXorExecute=0
+                DOTNET_NOLOGO=true
+                DOTNET_ROOT=/layers/heroku_dotnet/sdk
+                DOTNET_RUNNING_IN_CONTAINER=true
+                PATH=/layers/heroku_dotnet/sdk:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
+        );
+    });
 }
 
 #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
This PR is largely based on changes that were introduced in this draft https://github.com/heroku/buildpacks-dotnet/pull/204.

In particular it:
* Changes the NuGet cache layer definition to a `build` layer (to increase consistency with the SDK layer, which the NuGet layer will always be used with).
* Ensures that the environment scope for the NuGet layer is consistent with the SDK layer.
* Prepares the buildpack for configuring the availability of the SDK at launch, for instance when configured with `CNB_EXEC_ENV`. This includes
  * Always writing the layer environment (as this may change between builds for restored layers, based on user build configuration)
  * Only handling (e.g. copying) the runtime layer when the SDK isn't available at launch (which it currently never will be).
  * Determining whether the SDK layer will be available at launch based on the environment variable scope (e.g. it will/should be when the scope is either `Scope::All` or `Scope::Launch`.