### PR TITLE
Support `test` and `production` execution environments

### DIFF
--- a/buildpacks/dotnet/CHANGELOG.md
+++ b/buildpacks/dotnet/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for `test` and `production` execution environments. ([#222](https://github.com/heroku/buildpacks-dotnet/pull/222))
+
 ### Changed
 
 - The NuGet cache layer is now a build layer and available for later buildpacks. ([#221](https://github.com/heroku/buildpacks-dotnet/pull/221))

--- a/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
+++ b/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 #[derive(Debug, PartialEq)]
 pub(crate) struct DotnetBuildpackConfiguration {
     pub(crate) build_configuration: Option<String>,
-    execution_environment: ExecutionEnvironment,
+    pub(crate) execution_environment: ExecutionEnvironment,
     pub(crate) msbuild_verbosity_level: Option<VerbosityLevel>,
 }
 
@@ -53,7 +53,7 @@ fn detect_msbuild_verbosity_level(
 }
 
 #[derive(Debug, PartialEq)]
-enum ExecutionEnvironment {
+pub(crate) enum ExecutionEnvironment {
     Production,
     Test,
 }

--- a/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
+++ b/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::str::FromStr;
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct DotnetBuildpackConfiguration {
@@ -48,6 +49,24 @@ enum ExecutionEnvironment {
     Production,
 }
 
+impl FromStr for ExecutionEnvironment {
+    type Err = ExecutionEnvironmentError;
+
+    fn from_str(cnb_exec_env: &str) -> Result<Self, Self::Err> {
+        match cnb_exec_env {
+            "production" => Ok(ExecutionEnvironment::Production),
+            _ => Err(ExecutionEnvironmentError::UnsupportedExecutionEnvironment(
+                cnb_exec_env.to_string(),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum ExecutionEnvironmentError {
+    UnsupportedExecutionEnvironment(String),
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum VerbosityLevel {
     Quiet,
@@ -95,6 +114,22 @@ mod tests {
                 msbuild_verbosity_level: None
             }
         );
+    }
+
+    #[test]
+    fn test_parse_execution_environment() {
+        let cases = [
+            ("production", Ok(ExecutionEnvironment::Production)),
+            (
+                "foo",
+                Err(ExecutionEnvironmentError::UnsupportedExecutionEnvironment(
+                    "foo".to_string(),
+                )),
+            ),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(ExecutionEnvironment::from_str(input), expected);
+        }
     }
 
     #[test]

--- a/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
+++ b/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
@@ -3,6 +3,7 @@ use std::fmt;
 #[derive(Debug, PartialEq)]
 pub(crate) struct DotnetBuildpackConfiguration {
     pub(crate) build_configuration: Option<String>,
+    execution_environment: ExecutionEnvironment,
     pub(crate) msbuild_verbosity_level: Option<VerbosityLevel>,
 }
 
@@ -19,6 +20,7 @@ impl TryFrom<&libcnb::Env> for DotnetBuildpackConfiguration {
             build_configuration: env
                 .get("BUILD_CONFIGURATION")
                 .map(|value| value.to_string_lossy().to_string()),
+            execution_environment: ExecutionEnvironment::Production,
             msbuild_verbosity_level: detect_msbuild_verbosity_level(env).transpose()?,
         })
     }
@@ -39,6 +41,11 @@ fn detect_msbuild_verbosity_level(
                 DotnetBuildpackConfigurationError::InvalidMsbuildVerbosityLevel(value.to_string()),
             ),
         })
+}
+
+#[derive(Debug, PartialEq)]
+enum ExecutionEnvironment {
+    Production,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -84,6 +91,7 @@ mod tests {
             result,
             DotnetBuildpackConfiguration {
                 build_configuration: None,
+                execution_environment: ExecutionEnvironment::Production,
                 msbuild_verbosity_level: None
             }
         );

--- a/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
+++ b/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
@@ -55,6 +55,7 @@ fn detect_msbuild_verbosity_level(
 #[derive(Debug, PartialEq)]
 enum ExecutionEnvironment {
     Production,
+    Test,
 }
 
 impl FromStr for ExecutionEnvironment {
@@ -63,6 +64,7 @@ impl FromStr for ExecutionEnvironment {
     fn from_str(cnb_exec_env: &str) -> Result<Self, Self::Err> {
         match cnb_exec_env {
             "production" => Ok(ExecutionEnvironment::Production),
+            "test" => Ok(ExecutionEnvironment::Test),
             _ => Err(ExecutionEnvironmentError::UnsupportedExecutionEnvironment(
                 cnb_exec_env.to_string(),
             )),
@@ -125,9 +127,18 @@ mod tests {
     }
 
     #[test]
+    fn test_buildpack_configuration_test_execution_environment() {
+        let env = create_env(&[("CNB_EXEC_ENV", "test")]);
+        let result = DotnetBuildpackConfiguration::try_from(&env).unwrap();
+
+        assert_eq!(result.execution_environment, ExecutionEnvironment::Test);
+    }
+
+    #[test]
     fn test_parse_execution_environment() {
         let cases = [
             ("production", Ok(ExecutionEnvironment::Production)),
+            ("test", Ok(ExecutionEnvironment::Test)),
             (
                 "foo",
                 Err(ExecutionEnvironmentError::UnsupportedExecutionEnvironment(

--- a/buildpacks/dotnet/src/errors.rs
+++ b/buildpacks/dotnet/src/errors.rs
@@ -240,8 +240,8 @@ fn on_buildpack_error(error: &DotnetBuildpackError) {
                         "Unsupported execution environment'",
                         formatdoc! {"
                             The `CNB_EXEC_ENV` environment variable value (`{execution_environment}`)
-                            is not supported. This buildpack currently supports only `production`
-                            execution environments.
+                            is not supported. This buildpack currently supports `production` and
+                            `test` execution environments.
                         "},
                         None,
                     );

--- a/buildpacks/dotnet/src/errors.rs
+++ b/buildpacks/dotnet/src/errors.rs
@@ -1,6 +1,8 @@
 use crate::dotnet::target_framework_moniker::ParseTargetFrameworkError;
 use crate::dotnet::{project, solution};
-use crate::dotnet_buildpack_configuration::DotnetBuildpackConfigurationError;
+use crate::dotnet_buildpack_configuration::{
+    DotnetBuildpackConfigurationError, ExecutionEnvironmentError,
+};
 use crate::layers::sdk::SdkLayerError;
 use crate::DotnetBuildpackError;
 use bullet_stream::{style, Print};
@@ -230,6 +232,21 @@ fn on_buildpack_error(error: &DotnetBuildpackError) {
                     None,
                 );
             }
+            DotnetBuildpackConfigurationError::ExecutionEnvironmentError(error) => match error {
+                ExecutionEnvironmentError::UnsupportedExecutionEnvironment(
+                    execution_environment,
+                ) => {
+                    log_error(
+                        "Unsupported execution environment'",
+                        formatdoc! {"
+                            The `CNB_EXEC_ENV` environment variable value (`{execution_environment}`)
+                            is not supported. This buildpack currently supports only `production`
+                            execution environments.
+                        "},
+                        None,
+                    );
+                }
+            },
         },
         DotnetBuildpackError::RestoreDotnetToolsCommand(error) => match error {
             fun_run::CmdError::SystemError(_message, io_error) => log_io_error(

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -14,7 +14,7 @@ use crate::dotnet::runtime_identifier;
 use crate::dotnet::solution::Solution;
 use crate::dotnet::target_framework_moniker::{ParseTargetFrameworkError, TargetFrameworkMoniker};
 use crate::dotnet_buildpack_configuration::{
-    DotnetBuildpackConfiguration, DotnetBuildpackConfigurationError,
+    DotnetBuildpackConfiguration, DotnetBuildpackConfigurationError, ExecutionEnvironment,
 };
 use crate::dotnet_publish_command::DotnetPublishCommand;
 use crate::launch_process::LaunchProcessDetectionError;
@@ -117,7 +117,10 @@ impl Buildpack for DotnetBuildpack {
             style::details(format!("{}-{}", sdk_artifact.os, sdk_artifact.arch))
         ));
 
-        let sdk_scope = Scope::Build;
+        let sdk_scope = match buildpack_configuration.execution_environment {
+            ExecutionEnvironment::Production => Scope::Build,
+            ExecutionEnvironment::Test => Scope::All,
+        };
         let sdk_available_at_launch = sdk_scope == Scope::Launch || sdk_scope == Scope::All;
 
         let sdk_layer = layers::sdk::handle(&context, sdk_available_at_launch, sdk_artifact)?;

--- a/buildpacks/dotnet/tests/dotnet_publish_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_publish_test.rs
@@ -1,4 +1,4 @@
-use crate::tests::default_build_config;
+use crate::tests::{default_build_config, get_dotnet_arch};
 use indoc::{formatdoc, indoc};
 use libcnb_test::{assert_contains, assert_empty, PackResult, TestRunner};
 use regex::Regex;
@@ -183,15 +183,6 @@ fn test_dotnet_publish_with_global_json_and_custom_verbosity_level() {
 
 fn get_rid() -> String {
     format!("linux-{}", get_dotnet_arch())
-}
-
-fn get_dotnet_arch() -> String {
-    #[cfg(target_arch = "x86_64")]
-    let arch = "x64";
-    #[cfg(target_arch = "aarch64")]
-    let arch = "arm64";
-
-    arch.to_string()
 }
 
 fn replace_msbuild_log_patterns_with_placeholder(input: &str, placeholder: &str) -> String {

--- a/buildpacks/dotnet/tests/mod.rs
+++ b/buildpacks/dotnet/tests/mod.rs
@@ -17,3 +17,12 @@ pub(crate) fn default_build_config(fixture_path: impl AsRef<Path>) -> BuildConfi
     config.target_triple(target_triple);
     config
 }
+
+fn get_dotnet_arch() -> String {
+    #[cfg(target_arch = "x86_64")]
+    let arch = "x64";
+    #[cfg(target_arch = "aarch64")]
+    let arch = "arm64";
+
+    arch.to_string()
+}

--- a/buildpacks/dotnet/tests/sdk_installation_test.rs
+++ b/buildpacks/dotnet/tests/sdk_installation_test.rs
@@ -1,6 +1,6 @@
-use crate::tests::default_build_config;
-use indoc::indoc;
-use libcnb_test::{assert_contains, assert_empty, BuildpackReference, TestRunner};
+use crate::tests::{default_build_config, get_dotnet_arch};
+use indoc::{formatdoc, indoc};
+use libcnb_test::{assert_contains, assert_empty, BuildpackReference, ContainerConfig, TestRunner};
 
 #[test]
 #[ignore = "integration test"]
@@ -85,6 +85,37 @@ fn test_sdk_basic_install_build_environment() {
                 NUGET_XMLDOC_MODE=skip
                 PATH=/layers/heroku_dotnet/sdk:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
         );
+    });
+}
+
+#[test]
+#[ignore = "integration test"]
+fn test_sdk_basic_install_test_execution_environment() {
+    let mut config = default_build_config("tests/fixtures/project_with_nuget_sdk_and_global_json");
+    config.env("CNB_EXEC_ENV", "test");
+
+    TestRunner::default().build(&config, |context| {
+        assert_empty!(context.pack_stderr);
+
+        context.start_container(ContainerConfig::new().entrypoint("test"), |container| {
+            let log_output = container.logs_wait();
+            let dotnet_arch = get_dotnet_arch();
+
+            assert_empty!(log_output.stderr);
+            assert_contains!(
+                log_output.stdout,
+                &formatdoc! {"
+                    foo -> /workspace/bin/Debug/net9.0/foo.dll
+                      Run tests: '/workspace/bin/Debug/net9.0/foo.dll' [net9.0|{dotnet_arch}]
+                      Passed! - Failed: 0, Passed: 1, Skipped: 0, Total: 1"}
+            );
+            assert_contains!(
+                log_output.stdout,
+                &format!(
+                    "Tests succeeded: '/workspace/bin/Debug/net9.0/foo.dll' [net9.0|{dotnet_arch}"
+                )
+            );
+        });
     });
 }
 


### PR DESCRIPTION
This PR adds support for targeting multiple execution environments, based on [this RFC](https://github.com/buildpacks/rfcs/blob/8b8f8c511d12b601c71a281697c417ba5807f12f/text/0000-execution-environments.md).

The initial use case, and primary motivation for making these changes now, is to facilitate Heroku CI support in our classic .NET buildpack. [This related PR](https://github.com/heroku/heroku-buildpack-dotnet/pull/58) does just that.

Since the upstream RFC hasn't actually been implemented in any tooling/platforms/libraries at this point, implementing it in this context mostly means:

* Reading the [`CNB_EXEC_ENV` environment variable](https://github.com/buildpacks/rfcs/blob/8b8f8c511d12b601c71a281697c417ba5807f12f/text/0000-execution-environments.md#buildpack-api) to determine the environment to build for, and branching the build process accordingly (for `test` and `production` environments).
* The default execution environment is `production`, which does the same thing as before -- no logical changes are introduced to the default build process.
    * (On that note: The main `build` function has grown even larger as I didn't want to start refactoring that would make it harder to review/verify that the current logic has just been moved. Regardless, I'm planning on addressing that shortly, for both readability and testability).
* Adding support for a `test` execution environment when specified using `CNB_EXEC_ENV`. This first iteration is fairly basic, and essentially:
    * Skips `dotnet tool restore` and `dotnet publish` tasks, and doesn't create a `runtime` layer (which is included in the SDK).
    * Makes the .NET SDK and NuGet cache layers available as launch layers, and configures the .NET-specific environment accordingly.
        * The SDK is required to run [`dotnet test`](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test), which is currently the most reliable way to maximize compatibility, and support most testing platforms, frameworks, tools and configurations out of the box. I've added a few notes below on future improvements we'll likely want to explore to avoid including the SDK etc.
    * A launch process (named `test`) is always added to `launch.toml`, configured to run a `dotnet test` command with appropriate options/configuration to ensure consistency with the production workflow.
        * The `test` process will be used [by the classic buildpack](https://github.com/heroku/heroku-buildpack-dotnet/pull/58/files#diff-4e821476d5e4f5626c6f9fca337a47afe96a5e3daf23bccb02ad0bb109a9a407R16-R23).
* The implementation is of course limited by the fact that we can't yet leverage, define or rely on [for instance the `exec-env` key](https://github.com/buildpacks/rfcs/blob/8b8f8c511d12b601c71a281697c417ba5807f12f/text/0000-execution-environments.md#exec-env-key-in-toml) in `buildpack.toml` and `launch.toml` and related tooling. We'll also likely add support for determining execution environment in libcnb's build/target contexts, which should help clean up this code/certain functions.

There are several ways we could further expand on this support in the future:

* Publishing test executables [based exclusively on `Microsoft.Testing.Platform`](https://devblogs.microsoft.com/dotnet/mtp-adoption-frameworks/), automatically registered as process types (like we do already when building for production). This would, among other things, allow building test environments and run images without the full SDK.
* Restoring NuGet packages during the build. The test environment currently makes the NuGet cache layer available at launch, so if the source has previously been published, those packages will be available. Otherwise the packages will be restored by the `dotnet test` command.
* Restoring .NET tools and making them available during tests as well. .NET tools are currently only available during build, but we may want to make these available at launch for both test and production environments.

I'll make sure to add separate issues to track these.