### PR TITLE
Improve dotnet file detection log output

### DIFF
--- a/buildpacks/dotnet/CHANGELOG.md
+++ b/buildpacks/dotnet/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The buildpack will now restore .NET tools for any execution environment. ([#226](https://github.com/heroku/buildpacks-dotnet/pull/226))
 - Restored .NET tools are now available for later buildpacks. ([#226](https://github.com/heroku/buildpacks-dotnet/pull/226))
+- The log output now reflects whether a project or solution file was used for SDK version detection. ([#224](https://github.com/heroku/buildpacks-dotnet/pull/224))
 
 ## [0.3.3] - 2025-03-13
 

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -300,7 +300,7 @@ fn get_solution_to_publish(app_dir: &Path) -> Result<Solution, DotnetBuildpackEr
     // warning, or by building all solutions).
     if let Some(solution_file) = solution_file_paths.first() {
         print::sub_bullet(format!(
-            "Detected .NET solution to publish: {}",
+            "Detected .NET solution: {}",
             style::value(solution_file.to_string_lossy())
         ));
         Solution::load_from_path(solution_file).map_err(DotnetBuildpackError::LoadSolutionFile)
@@ -314,7 +314,7 @@ fn get_solution_to_publish(app_dir: &Path) -> Result<Solution, DotnetBuildpackEr
                     .map_err(DotnetBuildpackError::LoadProjectFile)
                     .inspect(|project| {
                         print::sub_bullet(format!(
-                            "Detected .NET project to publish: {}",
+                            "Detected .NET project: {}",
                             style::value(project.path.to_string_lossy())
                         ));
                     })?,

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -300,7 +300,7 @@ fn get_solution_to_publish(app_dir: &Path) -> Result<Solution, DotnetBuildpackEr
     // warning, or by building all solutions).
     if let Some(solution_file) = solution_file_paths.first() {
         print::sub_bullet(format!(
-            "Detected .NET file to publish: {}",
+            "Detected .NET solution to publish: {}",
             style::value(solution_file.to_string_lossy())
         ));
         Solution::load_from_path(solution_file).map_err(DotnetBuildpackError::LoadSolutionFile)
@@ -314,7 +314,7 @@ fn get_solution_to_publish(app_dir: &Path) -> Result<Solution, DotnetBuildpackEr
                     .map_err(DotnetBuildpackError::LoadProjectFile)
                     .inspect(|project| {
                         print::sub_bullet(format!(
-                            "Detected .NET file to publish: {}",
+                            "Detected .NET project to publish: {}",
                             style::value(project.path.to_string_lossy())
                         ));
                     })?,

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -156,7 +156,7 @@ impl Buildpack for DotnetBuildpack {
         let mut launch_builder = LaunchBuilder::new();
         match buildpack_configuration.execution_environment {
             ExecutionEnvironment::Production => {
-                print::bullet("Publish solution");
+                print::bullet("Publish app");
 
                 let mut publish_command = Command::from(DotnetPublishCommand {
                     path: solution.path.clone(),

--- a/buildpacks/dotnet/tests/dotnet_publish_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_publish_test.rs
@@ -159,7 +159,7 @@ fn test_dotnet_publish_with_global_json_and_custom_verbosity_level() {
             assert_contains!(
               replace_msbuild_log_patterns_with_placeholder(&context.pack_stdout, "<PLACEHOLDER>"), 
               &formatdoc! {r#"
-                - Publish solution
+                - Publish app
                   - Running `dotnet publish /workspace/foo.csproj --runtime {rid} "-p:PublishDir=bin/publish" --artifacts-path /tmp/build_artifacts --verbosity normal`
                 
                       MSBuild version 17.8.3+195e7f5a3 for .NET

--- a/buildpacks/dotnet/tests/sdk_installation_test.rs
+++ b/buildpacks/dotnet/tests/sdk_installation_test.rs
@@ -13,7 +13,7 @@ fn test_sdk_resolution_with_target_framework_8_0() {
                 context.pack_stdout,
                 &indoc! {r"
                     - SDK version detection
-                      - Detected .NET project to publish: `/workspace/foo.csproj`
+                      - Detected .NET project: `/workspace/foo.csproj`
                       - Inferring version requirement from `/workspace/foo.csproj`
                       - Detected version requirement: `^8.0`
                       - Resolved .NET SDK version `8.0"}
@@ -33,7 +33,7 @@ fn test_sdk_resolution_with_target_framework_9_0() {
                 context.pack_stdout,
                 &indoc! {r"
                     - SDK version detection
-                      - Detected .NET project to publish: `/workspace/foo.csproj`
+                      - Detected .NET project: `/workspace/foo.csproj`
                       - Inferring version requirement from `/workspace/foo.csproj`
                       - Detected version requirement: `^9.0`
                       - Resolved .NET SDK version `9.0"}
@@ -53,7 +53,7 @@ fn test_sdk_resolution_with_solution_file() {
                 context.pack_stdout,
                 &indoc! {r"
                     - SDK version detection
-                      - Detected .NET solution to publish: `/workspace/foo.sln`
+                      - Detected .NET solution: `/workspace/foo.sln`
                       - Inferring version requirement from `/workspace/foo.sln`
                       - Detected version requirement: `^8.0"}
             );
@@ -132,7 +132,7 @@ fn test_sdk_installation_with_global_json() {
                 context.pack_stdout,
                 &indoc! {r"
                     - SDK version detection
-                      - Detected .NET project to publish: `/workspace/foo.csproj`
+                      - Detected .NET project: `/workspace/foo.csproj`
                       - Detecting version requirement from root global.json file
                       - Detected version requirement: `=8.0.101`
                       - Resolved .NET SDK version `8.0.101` (linux-amd64)
@@ -167,7 +167,7 @@ fn test_sdk_installation_with_global_json() {
                 context.pack_stdout,
                 &indoc! {r"
                     - SDK version detection
-                      - Detected .NET project to publish: `/workspace/foo.csproj`
+                      - Detected .NET project: `/workspace/foo.csproj`
                       - Detecting version requirement from root global.json file
                       - Detected version requirement: `=8.0.101`
                       - Resolved .NET SDK version `8.0.101` (linux-arm64)
@@ -201,7 +201,7 @@ fn test_sdk_installation_with_global_json_prerelease_sdk() {
                 context.pack_stdout,
                 &indoc! {r"
                     - SDK version detection
-                      - Detected .NET project to publish: `/workspace/foo.csproj`
+                      - Detected .NET project: `/workspace/foo.csproj`
                       - Detecting version requirement from root global.json file
                       - Detected version requirement: `=9.0.100-rc.1.24452.12`
                       - Resolved .NET SDK version `9.0.100-rc.1.24452.12`"

--- a/buildpacks/dotnet/tests/sdk_installation_test.rs
+++ b/buildpacks/dotnet/tests/sdk_installation_test.rs
@@ -13,7 +13,7 @@ fn test_sdk_resolution_with_target_framework_8_0() {
                 context.pack_stdout,
                 &indoc! {r"
                     - SDK version detection
-                      - Detected .NET file to publish: `/workspace/foo.csproj`
+                      - Detected .NET project to publish: `/workspace/foo.csproj`
                       - Inferring version requirement from `/workspace/foo.csproj`
                       - Detected version requirement: `^8.0`
                       - Resolved .NET SDK version `8.0"}
@@ -33,7 +33,7 @@ fn test_sdk_resolution_with_target_framework_9_0() {
                 context.pack_stdout,
                 &indoc! {r"
                     - SDK version detection
-                      - Detected .NET file to publish: `/workspace/foo.csproj`
+                      - Detected .NET project to publish: `/workspace/foo.csproj`
                       - Inferring version requirement from `/workspace/foo.csproj`
                       - Detected version requirement: `^9.0`
                       - Resolved .NET SDK version `9.0"}
@@ -53,7 +53,7 @@ fn test_sdk_resolution_with_solution_file() {
                 context.pack_stdout,
                 &indoc! {r"
                     - SDK version detection
-                      - Detected .NET file to publish: `/workspace/foo.sln`
+                      - Detected .NET solution to publish: `/workspace/foo.sln`
                       - Inferring version requirement from `/workspace/foo.sln`
                       - Detected version requirement: `^8.0"}
             );
@@ -132,7 +132,7 @@ fn test_sdk_installation_with_global_json() {
                 context.pack_stdout,
                 &indoc! {r"
                     - SDK version detection
-                      - Detected .NET file to publish: `/workspace/foo.csproj`
+                      - Detected .NET project to publish: `/workspace/foo.csproj`
                       - Detecting version requirement from root global.json file
                       - Detected version requirement: `=8.0.101`
                       - Resolved .NET SDK version `8.0.101` (linux-amd64)
@@ -167,7 +167,7 @@ fn test_sdk_installation_with_global_json() {
                 context.pack_stdout,
                 &indoc! {r"
                     - SDK version detection
-                      - Detected .NET file to publish: `/workspace/foo.csproj`
+                      - Detected .NET project to publish: `/workspace/foo.csproj`
                       - Detecting version requirement from root global.json file
                       - Detected version requirement: `=8.0.101`
                       - Resolved .NET SDK version `8.0.101` (linux-arm64)
@@ -201,7 +201,7 @@ fn test_sdk_installation_with_global_json_prerelease_sdk() {
                 context.pack_stdout,
                 &indoc! {r"
                     - SDK version detection
-                      - Detected .NET file to publish: `/workspace/foo.csproj`
+                      - Detected .NET project to publish: `/workspace/foo.csproj`
                       - Detecting version requirement from root global.json file
                       - Detected version requirement: `=9.0.100-rc.1.24452.12`
                       - Resolved .NET SDK version `9.0.100-rc.1.24452.12`"


### PR DESCRIPTION
The log output now reflects whether a project or solution file was used for SDK version detection.