### PR TITLE
Refactor artifact resolution

### DIFF
--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -236,18 +236,16 @@ fn resolve_sdk_artifact(
     target: &Target,
     sdk_version_requirement: VersionReq,
 ) -> Result<Artifact<Version, Sha512, Option<()>>, DotnetBuildpackError> {
-    let target_os = target.os.parse::<Os>().expect(
-        "OS should always be parseable, buildpack will not run on unsupported operating systems.",
-    );
-    let target_arch = target.arch.parse::<Arch>().expect(
-        "Arch should always be parseable, buildpack will not run on unsupported architectures.",
-    );
     include_str!("../inventory.toml")
         .parse::<Inventory<_, _, _>>()
         .map_err(DotnetBuildpackError::ParseInventory)
         .map(|inventory| {
             inventory
-                .resolve(target_os, target_arch, &sdk_version_requirement)
+                .resolve(
+                    target.os.parse::<Os>().expect("OS should always be parseable, buildpack will not run on unsupported operating systems."),
+                    target.arch.parse::<Arch>().expect("Arch should always be parseable, buildpack will not run on unsupported architectures."),
+                    &sdk_version_requirement
+                )
                 .ok_or(DotnetBuildpackError::ResolveSdkVersion(
                     sdk_version_requirement,
                 ))

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -79,7 +79,7 @@ impl Buildpack for DotnetBuildpack {
             style::value(solution.path.to_string_lossy())
         ));
 
-        let sdk_version_requirement = detect_version_requirement(&context, &solution)?;
+        let sdk_version_requirement = detect_sdk_version_requirement(&context, &solution)?;
 
         let sdk_artifact = resolve_sdk_artifact(&context.target, sdk_version_requirement)?;
 
@@ -253,7 +253,7 @@ fn resolve_sdk_artifact(
         })
 }
 
-fn detect_version_requirement(
+fn detect_sdk_version_requirement(
     context: &BuildContext<DotnetBuildpack>,
     solution: &Solution,
 ) -> Result<VersionReq, DotnetBuildpackError> {

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -83,12 +83,6 @@ impl Buildpack for DotnetBuildpack {
 
         let sdk_artifact = resolve_sdk_artifact(&context.target, sdk_version_requirement)?;
 
-        print::sub_bullet(format!(
-            "Resolved .NET SDK version {} {}",
-            style::value(sdk_artifact.version.to_string()),
-            style::details(format!("{}-{}", sdk_artifact.os, sdk_artifact.arch))
-        ));
-
         let sdk_scope = match buildpack_configuration.execution_environment {
             ExecutionEnvironment::Production => Scope::Build,
             ExecutionEnvironment::Test => Scope::All,
@@ -250,6 +244,12 @@ fn resolve_sdk_artifact(
                     sdk_version_requirement,
                 ))
                 .cloned()
+                .inspect(|artifact|
+                    print::sub_bullet(format!(
+                        "Resolved .NET SDK version {} {}",
+                        style::value(artifact.version.to_string()),
+                        style::details(format!("{}-{}", artifact.os, artifact.arch))
+                    )))
         })?
 }
 

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -161,8 +161,8 @@ impl Buildpack for DotnetBuildpack {
                     path: solution.path.clone(),
                     configuration: buildpack_configuration.build_configuration,
                     runtime_identifier: runtime_identifier::get_runtime_identifier(
-                        target_os,
-                        target_arch,
+                        sdk_artifact.os,
+                        sdk_artifact.arch,
                     ),
                     verbosity_level: buildpack_configuration.msbuild_verbosity_level,
                 });

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -233,7 +233,7 @@ fn resolve_sdk_artifact(
     include_str!("../inventory.toml")
         .parse::<Inventory<_, _, _>>()
         .map_err(DotnetBuildpackError::ParseInventory)
-        .map(|inventory| {
+        .and_then(|inventory| {
             inventory
                 .resolve(
                     target.os.parse::<Os>().expect("OS should always be parseable, buildpack will not run on unsupported operating systems."),
@@ -250,7 +250,7 @@ fn resolve_sdk_artifact(
                         style::value(artifact.version.to_string()),
                         style::details(format!("{}-{}", artifact.os, artifact.arch))
                     )))
-        })?
+        })
 }
 
 fn detect_version_requirement(


### PR DESCRIPTION
This PR moves SDK version requirement and artifact resolution to separate functions, without any functional/logical changes to the current behavior.

The primary goal is to start breaking down the currently extremely long `build` function, and make it more testable in the process.

Very open to input on alternative approaches/ideas to consider to make this cleaner!