### PR TITLE
Restore .NET tools consistently across environments

### DIFF
--- a/buildpacks/dotnet/CHANGELOG.md
+++ b/buildpacks/dotnet/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The buildpack will now restore .NET tools for any execution environment. ([#226](https://github.com/heroku/buildpacks-dotnet/pull/226))
+- Restored .NET tools are now available for later buildpacks. ([#226](https://github.com/heroku/buildpacks-dotnet/pull/226))
+
 ## [0.3.3] - 2025-03-13
 
 ### Added

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -148,54 +148,54 @@ impl Buildpack for DotnetBuildpack {
                 ),
         )?;
 
+        let dotnet_cli_layer = context.uncached_layer(
+            layer_name!("dotnet-cli"),
+            UncachedLayerDefinition {
+                build: true,
+                launch: sdk_available_at_launch,
+            },
+        )?;
+        dotnet_cli_layer.write_env(LayerEnv::new().chainable_insert(
+            sdk_scope.clone(),
+            libcnb::layer_env::ModificationBehavior::Override,
+            "DOTNET_CLI_HOME",
+            dotnet_cli_layer.path(),
+        ))?;
+
+        let command_env = dotnet_cli_layer.read_env()?.apply(
+            Scope::Build,
+            &nuget_cache_layer.read_env()?.apply(
+                Scope::Build,
+                &sdk_layer
+                    .read_env()?
+                    .apply(Scope::Build, &Env::from_current()),
+            ),
+        );
+
+        if let Some(manifest_path) = detect::dotnet_tools_manifest_file(&context.app_dir) {
+            let mut restore_tools_command = Command::new("dotnet");
+            restore_tools_command
+                .args([
+                    "tool",
+                    "restore",
+                    "--tool-manifest",
+                    &manifest_path.to_string_lossy(),
+                ])
+                .current_dir(&context.app_dir)
+                .envs(&command_env);
+
+            print::bullet("Restore .NET tools");
+            print::sub_bullet("Tool manifest file detected");
+            print::sub_stream_with(
+                format!("Running {}", style::command(restore_tools_command.name())),
+                |stdout, stderr| restore_tools_command.stream_output(stdout, stderr),
+            )
+            .map_err(DotnetBuildpackError::RestoreDotnetToolsCommand)?;
+        }
+
         let mut launch_builder = LaunchBuilder::new();
         match buildpack_configuration.execution_environment {
             ExecutionEnvironment::Production => {
-                let dotnet_cli_layer = context.uncached_layer(
-                    layer_name!("dotnet-cli"),
-                    UncachedLayerDefinition {
-                        build: true,
-                        launch: sdk_available_at_launch,
-                    },
-                )?;
-                dotnet_cli_layer.write_env(LayerEnv::new().chainable_insert(
-                    sdk_scope.clone(),
-                    libcnb::layer_env::ModificationBehavior::Override,
-                    "DOTNET_CLI_HOME",
-                    dotnet_cli_layer.path(),
-                ))?;
-
-                let command_env = dotnet_cli_layer.read_env()?.apply(
-                    Scope::Build,
-                    &nuget_cache_layer.read_env()?.apply(
-                        Scope::Build,
-                        &sdk_layer
-                            .read_env()?
-                            .apply(Scope::Build, &Env::from_current()),
-                    ),
-                );
-
-                if let Some(manifest_path) = detect::dotnet_tools_manifest_file(&context.app_dir) {
-                    let mut restore_tools_command = Command::new("dotnet");
-                    restore_tools_command
-                        .args([
-                            "tool",
-                            "restore",
-                            "--tool-manifest",
-                            &manifest_path.to_string_lossy(),
-                        ])
-                        .current_dir(&context.app_dir)
-                        .envs(&command_env);
-
-                    print::bullet("Restore .NET tools");
-                    print::sub_bullet("Tool manifest file detected");
-                    print::sub_stream_with(
-                        format!("Running {}", style::command(restore_tools_command.name())),
-                        |stdout, stderr| restore_tools_command.stream_output(stdout, stderr),
-                    )
-                    .map_err(DotnetBuildpackError::RestoreDotnetToolsCommand)?;
-                }
-
                 print::bullet("Publish solution");
 
                 let mut publish_command = Command::from(DotnetPublishCommand {

--- a/buildpacks/dotnet/tests/dotnet_restore_tools_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_restore_tools_test.rs
@@ -16,12 +16,12 @@ fn test_dotnet_restore_and_run_dotnet_tool() {
                       - Tool manifest file detected
                       - Running `dotnet tool restore --tool-manifest /workspace/.config/dotnet-tools.json`
 
-                          Tool 'dotnetsay' (version '2.1.7') was restored. Available commands: dotnetsay
+                          Tool 'dotnet-ef' (version '8.0.14') was restored. Available commands: dotnet-ef
 
                           Restore was successful."}
             );
-            assert_contains!(&context.pack_stdout, "Running dotnetsay post-publish");
-            assert_contains!(&context.pack_stdout, "__________________");
+            assert_contains!(&context.pack_stdout, "Running dotnet-ef tool post-publish");
+            assert_contains!(&context.pack_stdout, "Entity Framework Core .NET Command-line Tools 8.0.14");
         },
     );
 }

--- a/buildpacks/dotnet/tests/dotnet_restore_tools_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_restore_tools_test.rs
@@ -28,6 +28,23 @@ fn test_dotnet_restore_and_run_dotnet_tool() {
 
 #[test]
 #[ignore = "integration test"]
+fn test_dotnet_restore_dotnet_tool_test_execution_environment() {
+    TestRunner::default().build(
+        default_build_config("tests/fixtures/console_with_dotnet_tool")
+            .env("CNB_EXEC_ENV", "test"),
+        |context| {
+            assert_empty!(context.pack_stderr);
+            assert_contains!(&context.pack_stdout, "Running `dotnet tool restore --tool-manifest /workspace/.config/dotnet-tools.json`");
+
+            let command_output = context.run_shell_command("dotnet tool run dotnet-ef");
+            assert_empty!(&command_output.stderr);
+            assert_contains!(&command_output.stdout, "Entity Framework Core .NET Command-line Tools 8.0.14");
+        },
+    );
+}
+
+#[test]
+#[ignore = "integration test"]
 fn test_dotnet_restore_dotnet_tool_with_configuration_error() {
     TestRunner::default().build(
         default_build_config("tests/fixtures/console_with_dotnet_tool_configuration_error")

--- a/buildpacks/dotnet/tests/fixtures/console_with_dotnet_tool/.config/dotnet-tools.json
+++ b/buildpacks/dotnet/tests/fixtures/console_with_dotnet_tool/.config/dotnet-tools.json
@@ -2,10 +2,10 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "dotnetsay": {
-      "version": "2.1.7",
+    "dotnet-ef": {
+      "version": "8.0.14",
       "commands": [
-        "dotnetsay"
+        "dotnet-ef"
       ],
       "rollForward": false
     }

--- a/buildpacks/dotnet/tests/fixtures/console_with_dotnet_tool/consoleapp.csproj
+++ b/buildpacks/dotnet/tests/fixtures/console_with_dotnet_tool/consoleapp.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <Target Name="PostPublishStep" AfterTargets="Publish">
-    <Message Text="Running dotnetsay post-publish" Importance="High" />
-    <Exec Command="dotnet tool run dotnetsay" />
+    <Message Text="Running dotnet-ef tool post-publish" Importance="High" />
+    <Exec Command="dotnet tool run dotnet-ef" />
   </Target>
 
 </Project>

--- a/buildpacks/dotnet/tests/sdk_installation_test.rs
+++ b/buildpacks/dotnet/tests/sdk_installation_test.rs
@@ -76,6 +76,7 @@ fn test_sdk_basic_install_build_environment() {
             context.pack_stdout,
             &indoc! {"
                 ## Testing buildpack ##
+                DOTNET_CLI_HOME=/layers/heroku_dotnet/dotnet-cli
                 DOTNET_CLI_TELEMETRY_OPTOUT=true
                 DOTNET_EnableWriteXorExecute=0
                 DOTNET_NOLOGO=true


### PR DESCRIPTION
This PR builds on the basic .NET tool restore functionality introduced in https://github.com/heroku/buildpacks-dotnet/pull/194:

* The previous PR stated that local tools would only be available during the "build". While that is true in the context of the dotnet build/publish executed by this buildpack, .NET tools wouldn't actually be available for subsequent buildpacks for a couple reasons:
  * Local .NET tools are usually restored to the NuGet packages directory. The `nuget_cache` layer wasn't a CNB `build` layer at the time, but this was recently addressed https://github.com/heroku/buildpacks-dotnet/pull/221
  * Even if the NuGet package for a tool was installed and available when running `dotnet tool run {tool-command}`, the tool would still require a `dotnet tool restore`, as the CLI depends on certain supporting files to run tool commands as expected.
     * This has been addressed by creating an uncached `dotnet-cli` layer and [setting the `DOTNET_CLI_HOME` environment variable](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_cli_home) to that layer's path.
      
        For the test fixture that was adapted in this PR, this specifically means that the `dotnet-ef` tool will, following a successful `dotnet tool restore`, have a corresponding "tool resolver cache" file in the `DOTNET_CLI_HOME` (referencing, among other things, the executable location in the NuGet cache layer), e.g.:
      
        `$ cat /layers/heroku_dotnet/dotnet-cli/.dotnet/toolResolverCache/1/dotnet-ef
      [{"Version":"8.0.14","TargetFramework":"net9.0","RuntimeIdentifier":"any","Name":"dotnet-ef","Runner":"dotnet","PathToExecutable":"/layers/heroku_dotnet/nuget-cache/dotnet-ef/8.0.14/tools/net8.0/any/dotnet-ef.dll"}]`
* Support for both `test` and `production` execution environments was recently introduced https://github.com/heroku/buildpacks-dotnet/pull/222. As noted in that PR, `test` execution environments would skip tool restoration to keep the changes introduced to a minimum.
  * This PR expands .NET tool restore support to `test` execution environments as well, applying the same environment variable scope and launch layer availability settings used for the `sdk` and `nuget-cache` layers to the new `dotnet-cli` layer.