### PR TITLE
Prefer solution file name in test process command

### DIFF
--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -212,7 +212,14 @@ impl Buildpack for DotnetBuildpack {
                 };
             }
             ExecutionEnvironment::Test => {
-                let mut args = vec![format!("dotnet test {}", solution.path.to_string_lossy())];
+                let mut args = vec![format!(
+                    "dotnet test {}",
+                    solution
+                        .path
+                        .file_name()
+                        .expect("Solution to have a file name")
+                        .to_string_lossy()
+                )];
                 if let Some(configuration) = buildpack_configuration.build_configuration {
                     args.push(format!("--configuration {configuration}"));
                 }


### PR DESCRIPTION
This changes the test launch process command, registered when targeting the `test` execution environment, to use only the solution file name rather than the absolute solution file path.

The motivation for this change is the same as https://github.com/heroku/buildpacks-dotnet/pull/138 (though there's no need to change directory in this case, as we're only testing the solution file, which is currently always found in the workspace/build directory root). More specifically, it'll allow running the `test` process type in (currently unsupported) environments, such as local integration tests, or Heroku apps built with `CNB_EXEC_ENV=test` using `heroku run test`.

This shouldn't change the current behavior in any supported environments (including Heroku CI), which all execute the test command from the working directory containing the solution file.