### PR TITLE
Refactor launch process detection

### DIFF
--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -48,14 +48,17 @@ fn project_launch_process(
     }
 
     Some(
-        project
-            .assembly_name
-            .parse::<ProcessType>()
-            .map_err(LaunchProcessDetectionError::ProcessType)
-            .map(|process_type| {
-                ProcessBuilder::new(process_type, ["bash", "-c", &command]).build()
-            }),
+        project_process_type(project).map(|process_type| {
+            ProcessBuilder::new(process_type, ["bash", "-c", &command]).build()
+        }),
     )
+}
+
+fn project_process_type(project: &Project) -> Result<ProcessType, LaunchProcessDetectionError> {
+    project
+        .assembly_name
+        .parse::<ProcessType>()
+        .map_err(LaunchProcessDetectionError::ProcessType)
 }
 
 fn relative_executable_path(solution: &Solution, project: &Project) -> PathBuf {

--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -1,6 +1,8 @@
 use crate::dotnet::project::ProjectType;
 use crate::dotnet::solution::Solution;
+use crate::Project;
 use libcnb::data::launch::{Process, ProcessBuilder, ProcessType, ProcessTypeError};
+use std::path::PathBuf;
 
 #[derive(Debug)]
 pub(crate) enum LaunchProcessDetectionError {
@@ -22,13 +24,7 @@ pub(crate) fn detect_solution_processes(
             )
         })
         .map(|project| {
-            let executable_path = project
-                .path
-                .parent()
-                .expect("Project file should always have a parent directory")
-                .join("bin")
-                .join("publish")
-                .join(&project.assembly_name);
+            let executable_path = project_executable_path(project);
 
             let relative_executable_path = executable_path
                 .strip_prefix(
@@ -64,4 +60,14 @@ pub(crate) fn detect_solution_processes(
                 })
         })
         .collect::<Result<_, _>>()
+}
+
+fn project_executable_path(project: &Project) -> PathBuf {
+    project
+        .path
+        .parent()
+        .expect("Project file should always have a parent directory")
+        .join("bin")
+        .join("publish")
+        .join(&project.assembly_name)
 }

--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -2,7 +2,7 @@ use crate::dotnet::project::ProjectType;
 use crate::dotnet::solution::Solution;
 use crate::Project;
 use libcnb::data::launch::{Process, ProcessBuilder, ProcessType, ProcessTypeError};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 #[derive(Debug)]
 pub(crate) enum LaunchProcessDetectionError {
@@ -24,9 +24,7 @@ pub(crate) fn detect_solution_processes(
             )
         })
         .map(|project| {
-            let executable_path = project_executable_path(project);
-
-            let relative_executable_path = relative_executable_path(solution, executable_path);
+            let relative_executable_path = relative_executable_path(solution, project);
 
             let mut command = format!(
                 "cd {}; ./{}",
@@ -55,8 +53,8 @@ pub(crate) fn detect_solution_processes(
         .collect::<Result<_, _>>()
 }
 
-fn relative_executable_path(solution: &Solution, executable_path: &PathBuf) -> PathBuf {
-    executable_path
+fn relative_executable_path(solution: &Solution, project: &Project) -> PathBuf {
+    project_executable_path(project)
         .strip_prefix(
             solution
                 .path

--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -2,7 +2,7 @@ use crate::dotnet::project::ProjectType;
 use crate::dotnet::solution::Solution;
 use crate::Project;
 use libcnb::data::launch::{Process, ProcessBuilder, ProcessType, ProcessTypeError};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
 pub(crate) enum LaunchProcessDetectionError {
@@ -26,14 +26,7 @@ pub(crate) fn detect_solution_processes(
         .map(|project| {
             let executable_path = project_executable_path(project);
 
-            let relative_executable_path = executable_path
-                .strip_prefix(
-                    solution
-                        .path
-                        .parent()
-                        .expect("Solution path to have a parent"),
-                )
-                .expect("Project to be nested in solution parent directory");
+            let relative_executable_path = relative_executable_path(solution, executable_path);
 
             let mut command = format!(
                 "cd {}; ./{}",
@@ -60,6 +53,18 @@ pub(crate) fn detect_solution_processes(
                 })
         })
         .collect::<Result<_, _>>()
+}
+
+fn relative_executable_path(solution: &Solution, executable_path: &PathBuf) -> PathBuf {
+    executable_path
+        .strip_prefix(
+            solution
+                .path
+                .parent()
+                .expect("Solution path to have a parent"),
+        )
+        .expect("Project to be nested in solution parent directory")
+        .to_path_buf()
 }
 
 fn project_executable_path(project: &Project) -> PathBuf {

--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -9,6 +9,7 @@ pub(crate) enum LaunchProcessDetectionError {
     ProcessType(ProcessTypeError),
 }
 
+/// Detects processes in a solution's projects
 pub(crate) fn detect_solution_processes(
     solution: &Solution,
 ) -> Result<Vec<Process>, LaunchProcessDetectionError> {
@@ -19,6 +20,7 @@ pub(crate) fn detect_solution_processes(
         .collect::<Result<_, _>>()
 }
 
+/// Determines if a project should have a launchable process and constructs it
 fn project_launch_process(
     solution: &Solution,
     project: &Project,
@@ -61,6 +63,7 @@ fn project_process_type(project: &Project) -> Result<ProcessType, LaunchProcessD
         .map_err(LaunchProcessDetectionError::ProcessType)
 }
 
+/// Returns the (expected) relative executable path from the solution's parent directory
 fn relative_executable_path(solution: &Solution, project: &Project) -> PathBuf {
     project_executable_path(project)
         .strip_prefix(
@@ -73,6 +76,7 @@ fn relative_executable_path(solution: &Solution, project: &Project) -> PathBuf {
         .to_path_buf()
 }
 
+/// Returns the (expected) absolute path to the project's compiled executable
 fn project_executable_path(project: &Project) -> PathBuf {
     project
         .path


### PR DESCRIPTION
This PR splits the `launch_process::detect_solution_processes` function into smaller functions without changing the current logic, and tests the current behavior to prepare for upcoming changes (like https://github.com/heroku/buildpacks-dotnet/pull/237).