### PR TITLE
Filter allowed process type characters

### DIFF
--- a/buildpacks/dotnet/CHANGELOG.md
+++ b/buildpacks/dotnet/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The buildpack now sanitizes launch process type names, based on project assembly names, by filtering out invalid characters. ([#237](https://github.com/heroku/buildpacks-dotnet/pull/237))
+
 ## [0.3.5] - 2025-03-19
 
 ### Added

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -17,12 +17,10 @@ use crate::dotnet_buildpack_configuration::{
     DotnetBuildpackConfiguration, DotnetBuildpackConfigurationError, ExecutionEnvironment,
 };
 use crate::dotnet_publish_command::DotnetPublishCommand;
-use crate::launch_process::LaunchProcessDetectionError;
 use crate::layers::sdk::SdkLayerError;
 use bullet_stream::global::print;
 use bullet_stream::style;
 use fun_run::CommandWithName;
-use indoc::formatdoc;
 use inventory::artifact::{Arch, Os};
 use inventory::{Inventory, ParseInventoryError};
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
@@ -182,34 +180,26 @@ impl Buildpack for DotnetBuildpack {
 
                 print::bullet("Process types");
                 print::sub_bullet("Detecting process types from published artifacts");
-                match launch_process::detect_solution_processes(&solution) {
-                    Ok(processes) => {
-                        if processes.is_empty() {
-                            print::sub_bullet("No processes were detected");
-                        } else {
-                            for process in &processes {
-                                print::sub_bullet(format!(
-                                    "Found {}: {}",
-                                    style::value(process.r#type.to_string()),
-                                    process.command.join(" ")
-                                ));
-                            }
-                            if Path::exists(&context.app_dir.join("Procfile")) {
-                                print::sub_bullet("Procfile detected");
-                                print::sub_bullet("Skipping process type registration (add process types to your Procfile as needed)");
-                            } else {
-                                launch_builder.processes(processes);
-                                print::sub_bullet("No Procfile detected");
-                                print::sub_bullet(
-                                    "Registering detected process types as launch processes",
-                                );
-                            };
-                        }
+                let processes = launch_process::detect_solution_processes(&solution);
+                if processes.is_empty() {
+                    print::sub_bullet("No processes were detected");
+                } else {
+                    for process in &processes {
+                        print::sub_bullet(format!(
+                            "Found {}: {}",
+                            style::value(process.r#type.to_string()),
+                            process.command.join(" ")
+                        ));
                     }
-                    Err(error) => {
-                        log_launch_process_detection_warning(error);
-                    }
-                };
+                    if Path::exists(&context.app_dir.join("Procfile")) {
+                        print::sub_bullet("Procfile detected");
+                        print::sub_bullet("Skipping process type registration (add process types to your Procfile as needed)");
+                    } else {
+                        launch_builder.processes(processes);
+                        print::sub_bullet("No Procfile detected");
+                        print::sub_bullet("Registering detected process types as launch processes");
+                    };
+                }
             }
             ExecutionEnvironment::Test => {
                 let mut args = vec![format!(
@@ -372,37 +362,6 @@ fn detect_global_json_sdk_configuration(
                 })
         },
     )
-}
-
-fn log_launch_process_detection_warning(error: LaunchProcessDetectionError) {
-    match error {
-        LaunchProcessDetectionError::ProcessType(process_type_error) => {
-            print::warning(formatdoc! {"
-                {process_type_error}
-
-                Launch process detection error
-
-                We detected an invalid launch process type.
-
-                The buildpack automatically tries to register Cloud Native Buildpacks (CNB)
-                process types for console and web projects after successfully publishing an
-                application.
-
-                Process type names are based on the filenames of compiled project executables,
-                which is usually the project name. For example, `webapi` for a `webapi.csproj`
-                project. In some cases, these names are be incompatible with the CNB spec as 
-                process types can only contain numbers, letters, and the characters `.`, `_`,
-                and `-`.
-
-                To use this automatic launch process type registration, see the warning details
-                above to troubleshoot and make necessary adjustments.
-
-                If you think you found a bug in the buildpack, or have feedback on improving
-                the behavior for your use case, file an issue here:
-                https://github.com/heroku/buildpacks-dotnet/issues/new
-            "});
-        }
-    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
We currently use the project assembly name to build launch process types. However, assembly names can include several characters that are not allowed [in the CNB spec](https://github.com/buildpacks/spec/blob/d29ba81518b7304700e9e8a54cc2194fa732e51b/buildpack.md?plain=1#L930).

This PR changes the launch process type to only include characters allowed by the CNB spec, eliminating the need to warn users when an invalid character is included in the assembly name. It also allows us to safely make the `detect_solution_process` infallible, reducing code complexity in the process.

Future improvements to consider:
* While somewhat unlikely, this change could cause errors if the sanitized launch process names for two or more projects are identical (e.g. `foo+bar.csproj`, `foobar.csproj`, `foo bar.csproj` will all use the `foobar` process type name), which the [CNB spec doesn't allow](https://github.com/buildpacks/spec/blob/d29ba81518b7304700e9e8a54cc2194fa732e51b/buildpack.md?plain=1#L929).
* As noted in https://github.com/heroku/buildpacks-dotnet/issues/188, we may want to also filter out `.`, even if it's allowed under the CNB spec, to increase compatibility with the `Procfile` spec (which only allows [alphanumeric characters + hyphens and underscores](https://devcenter.heroku.com/articles/preparing-a-codebase-for-heroku-deployment#3-add-a-procfile)). Using `.` in .NET project names (e.g. `MyApp.Frontend`) is fairly common, so this is more likely to cause issues for users of this buildpack.
* On that note, we may also want to always use lower case process types (as process types with upper cased characters has historically caused issues on certain platforms).