### PR TITLE
Quote launch process command paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "shell-words",
  "tempfile",
 ]
 
@@ -1535,6 +1536,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shlex"

--- a/buildpacks/dotnet/CHANGELOG.md
+++ b/buildpacks/dotnet/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The buildpack now sanitizes launch process type names, based on project assembly names, by filtering out invalid characters. ([#237](https://github.com/heroku/buildpacks-dotnet/pull/237))
+- Launch process commands with paths containing special characters (including spaces) are now properly quoted. ([#239](https://github.com/heroku/buildpacks-dotnet/pull/239))
 
 ## [0.3.5] - 2025-03-19
 

--- a/buildpacks/dotnet/Cargo.toml
+++ b/buildpacks/dotnet/Cargo.toml
@@ -22,6 +22,7 @@ semver = "1.0"
 serde = "1"
 serde_json = "1"
 sha2 = "0.10"
+shell-words = "1.1.0"
 
 [dev-dependencies]
 libcnb-test = "0.28"

--- a/buildpacks/dotnet/src/dotnet/project.rs
+++ b/buildpacks/dotnet/src/dotnet/project.rs
@@ -48,7 +48,7 @@ struct Metadata {
     assembly_name: Option<String>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub(crate) enum ProjectType {
     ConsoleApplication,
     WebApplication,

--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -25,14 +25,18 @@ fn project_launch_process(solution: &Solution, project: &Project) -> Option<Proc
 
     let mut command = format!(
         "cd {}; ./{}",
-        relative_executable_path
-            .parent()
-            .expect("Path to always have a parent directory")
-            .display(),
-        relative_executable_path
-            .file_name()
-            .expect("Path to never terminate in `..`")
-            .to_string_lossy()
+        shell_words::quote(
+            &relative_executable_path
+                .parent()
+                .expect("Path to always have a parent directory")
+                .to_string_lossy()
+        ),
+        shell_words::quote(
+            &relative_executable_path
+                .file_name()
+                .expect("Path to never terminate in `..`")
+                .to_string_lossy()
+        )
     );
 
     if project.project_type == ProjectType::WebApplication {

--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -69,9 +69,9 @@ fn relative_executable_path(solution: &Solution, project: &Project) -> PathBuf {
             solution
                 .path
                 .parent()
-                .expect("Solution path to have a parent"),
+                .expect("Solution file should be in a directory"),
         )
-        .expect("Project to be nested in solution parent directory")
+        .expect("Executable path should inside the solution's directory")
         .to_path_buf()
 }
 

--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -23,13 +23,13 @@ fn project_launch_process(solution: &Solution, project: &Project) -> Option<Proc
     }
     let relative_executable_path = relative_executable_path(solution, project);
 
-    let command = build_command(&relative_executable_path, &project.project_type);
+    let command = build_command(&relative_executable_path, project.project_type);
 
     Some(ProcessBuilder::new(project_process_type(project), ["bash", "-c", &command]).build())
 }
 
 /// Constructs the shell command for launching the process
-fn build_command(relative_executable_path: &Path, project_type: &ProjectType) -> String {
+fn build_command(relative_executable_path: &Path, project_type: ProjectType) -> String {
     let parent_dir = relative_executable_path
         .parent()
         .expect("Executable path should always have a parent directory")
@@ -48,7 +48,7 @@ fn build_command(relative_executable_path: &Path, project_type: &ProjectType) ->
         shell_words::quote(file_name)
     );
 
-    if project_type == &ProjectType::WebApplication {
+    if project_type == ProjectType::WebApplication {
         command.push_str(" --urls http://*:$PORT");
     }
 
@@ -200,12 +200,12 @@ mod tests {
         let executable_path = PathBuf::from("some/project with spaces/bin/publish/My App");
 
         assert_eq!(
-            build_command(&executable_path, &ProjectType::ConsoleApplication),
+            build_command(&executable_path, ProjectType::ConsoleApplication),
             "cd 'some/project with spaces/bin/publish'; ./'My App'"
         );
 
         assert_eq!(
-            build_command(&executable_path, &ProjectType::WebApplication),
+            build_command(&executable_path, ProjectType::WebApplication),
             "cd 'some/project with spaces/bin/publish'; ./'My App' --urls http://*:$PORT"
         );
     }
@@ -216,7 +216,7 @@ mod tests {
             PathBuf::from("some/project with #special$chars/bin/publish/My-App+v1.2_Release!");
 
         assert_eq!(
-            build_command(&executable_path, &ProjectType::ConsoleApplication),
+            build_command(&executable_path, ProjectType::ConsoleApplication),
             "cd 'some/project with #special$chars/bin/publish'; ./My-App+v1.2_Release!"
         );
     }

--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -33,17 +33,19 @@ fn build_command(relative_executable_path: &Path, project_type: &ProjectType) ->
     let parent_dir = relative_executable_path
         .parent()
         .expect("Executable path should always have a parent directory")
-        .to_string_lossy();
+        .to_str()
+        .expect("Path should be valid UTF-8");
 
     let file_name = relative_executable_path
         .file_name()
         .expect("Executable path should always have a file name")
-        .to_string_lossy();
+        .to_str()
+        .expect("Path should be valid UTF-8");
 
     let mut command = format!(
         "cd {}; ./{}",
-        shell_words::quote(&parent_dir),
-        shell_words::quote(&file_name)
+        shell_words::quote(parent_dir),
+        shell_words::quote(file_name)
     );
 
     if project_type == &ProjectType::WebApplication {


### PR DESCRIPTION
This PR primarily ensures that paths used in launch processes containing special characters are properly escaped and shell compatible.