### PR TITLE
Fix Clippy errors with Rust 1.86

### DIFF
--- a/buildpacks/dotnet/src/dotnet_sdk_command.rs
+++ b/buildpacks/dotnet/src/dotnet_sdk_command.rs
@@ -31,7 +31,7 @@ impl From<DotnetPublishCommand> for Command {
         }
         if let Some(verbosity_level) = value.verbosity_level {
             command.args(["--verbosity", &verbosity_level.to_string()]);
-        };
+        }
         command
     }
 }

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -205,7 +205,7 @@ impl Buildpack for DotnetBuildpack {
                         launch_builder.processes(processes);
                         print::sub_bullet("No Procfile detected");
                         print::sub_bullet("Registering detected process types as launch processes");
-                    };
+                    }
                 }
             }
             ExecutionEnvironment::Test => {


### PR DESCRIPTION
To unblock #247.

Fixes:

```
 error: unnecessary semicolon
  --> buildpacks/dotnet/src/dotnet_sdk_command.rs:34:10
   |
34 |         };
   |          ^ help: remove
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_semicolon
   = note: `-D clippy::unnecessary-semicolon` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::unnecessary_semicolon)]`

error: unnecessary semicolon
   --> buildpacks/dotnet/src/main.rs:208:22
    |
208 |                     };
    |                      ^ help: remove
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_semicolon
```