### PR TITLE
Improve process type naming

### DIFF
--- a/buildpacks/dotnet/CHANGELOG.md
+++ b/buildpacks/dotnet/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The buildpack now lowercases launch process type names, and replaces spaces, dots (`.`), and underscores (`_`) with hyphens (`-`) for broader compatibility. ([#252](https://github.com/heroku/buildpacks-dotnet/pull/252))
+
 ## [0.4.1] - 2025-04-09
 
 ### Added

--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -74,7 +74,8 @@ fn build_command(relative_executable_path: &Path, project_type: ProjectType) -> 
 
 /// Returns a sanitized process type name, ensuring it is always valid
 fn project_process_type(project: &Project) -> ProcessType {
-    sanitize_process_type_name(&project.assembly_name)
+    utils::to_rfc1123_label(&project.assembly_name)
+        .expect("Input to contain RFC 1123 characters")
         .parse::<ProcessType>()
         .expect("Sanitized process type name should always be valid")
 }
@@ -101,13 +102,6 @@ fn project_executable_path(project: &Project) -> PathBuf {
         .join("bin")
         .join("publish")
         .join(&project.assembly_name)
-}
-
-/// Sanitizes a process type name to only contain allowed characters
-fn sanitize_process_type_name(input: &str) -> String {
-    utils::to_rfc1123_label(input)
-        .expect("Input to contain RFC 1123 characters")
-        .to_string()
 }
 
 #[cfg(test)]

--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -105,14 +105,9 @@ fn project_executable_path(project: &Project) -> PathBuf {
 
 /// Sanitizes a process type name to only contain allowed characters
 fn sanitize_process_type_name(input: &str) -> String {
-    utils::to_rfc1123_label(
-        &input
-            .chars()
-            .filter(|c| !c.is_whitespace())
-            .collect::<String>(),
-    )
-    .expect("Input to contain RFC 1123 characters")
-    .to_string()
+    utils::to_rfc1123_label(input)
+        .expect("Input to contain RFC 1123 characters")
+        .to_string()
 }
 
 #[cfg(test)]
@@ -210,7 +205,7 @@ mod tests {
         };
 
         let expected_processes = vec![Process {
-            r#type: process_type!("myapp"),
+            r#type: process_type!("my-app"),
             command: vec![
                 "bash".to_string(),
                 "-c".to_string(),
@@ -287,7 +282,7 @@ mod tests {
     fn test_sanitize_process_type_name() {
         assert_eq!(
             sanitize_process_type_name("Hello, world! 123"),
-            "helloworld123"
+            "hello-world-123"
         );
         assert_eq!(
             sanitize_process_type_name("This_is-a.test.123.abc"),
@@ -295,15 +290,15 @@ mod tests {
         );
         assert_eq!(
             sanitize_process_type_name("Special chars: !@#$%+^&*()"),
-            "specialchars"
+            "special-chars"
         );
         assert_eq!(
             sanitize_process_type_name("Mixed: aBc123.xyz_-!@#"),
-            "mixedabc123-xyz"
+            "mixed-abc123-xyz"
         );
         assert_eq!(
             sanitize_process_type_name("Unicode: 日本語123"),
-            "unicode123"
+            "unicode-123"
         );
     }
 }

--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -75,7 +75,7 @@ fn build_command(relative_executable_path: &Path, project_type: ProjectType) -> 
 /// Returns a sanitized process type name, ensuring it is always valid
 fn project_process_type(project: &Project) -> ProcessType {
     utils::to_rfc1123_label(&project.assembly_name)
-        .expect("Input to contain RFC 1123 characters")
+        .expect("Assembly name to include at least one character compatible with the RFC 1123 DNS label spec")
         .parse::<ProcessType>()
         .expect("Sanitized process type name should always be valid")
 }

--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -108,7 +108,7 @@ fn sanitize_process_type_name(input: &str) -> String {
     utils::to_rfc1123_label(
         &input
             .chars()
-            .filter(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_'))
+            .filter(|c| !c.is_whitespace())
             .collect::<String>(),
     )
     .expect("Input to contain RFC 1123 characters")

--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -277,28 +277,4 @@ mod tests {
             "cd 'some/project with #special$chars/bin/publish'; ./My-App+v1.2_Release!"
         );
     }
-
-    #[test]
-    fn test_sanitize_process_type_name() {
-        assert_eq!(
-            sanitize_process_type_name("Hello, world! 123"),
-            "hello-world-123"
-        );
-        assert_eq!(
-            sanitize_process_type_name("This_is-a.test.123.abc"),
-            "this-is-a-test-123-abc"
-        );
-        assert_eq!(
-            sanitize_process_type_name("Special chars: !@#$%+^&*()"),
-            "special-chars"
-        );
-        assert_eq!(
-            sanitize_process_type_name("Mixed: aBc123.xyz_-!@#"),
-            "mixed-abc123-xyz"
-        );
-        assert_eq!(
-            sanitize_process_type_name("Unicode: 日本語123"),
-            "unicode-123"
-        );
-    }
 }

--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -1,6 +1,6 @@
-use crate::Project;
 use crate::dotnet::project::ProjectType;
 use crate::dotnet::solution::Solution;
+use crate::{Project, utils};
 use libcnb::data::launch::{Process, ProcessBuilder, ProcessType};
 use libcnb::data::process_type;
 use std::path::{Path, PathBuf};
@@ -105,10 +105,14 @@ fn project_executable_path(project: &Project) -> PathBuf {
 
 /// Sanitizes a process type name to only contain allowed characters
 fn sanitize_process_type_name(input: &str) -> String {
-    input
-        .chars()
-        .filter(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_'))
-        .collect()
+    utils::to_rfc1123_label(
+        &input
+            .chars()
+            .filter(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_'))
+            .collect::<String>(),
+    )
+    .expect("Input to contain RFC 1123 characters")
+    .to_string()
 }
 
 #[cfg(test)]
@@ -206,7 +210,7 @@ mod tests {
         };
 
         let expected_processes = vec![Process {
-            r#type: process_type!("MyApp"),
+            r#type: process_type!("myapp"),
             command: vec![
                 "bash".to_string(),
                 "-c".to_string(),
@@ -283,23 +287,23 @@ mod tests {
     fn test_sanitize_process_type_name() {
         assert_eq!(
             sanitize_process_type_name("Hello, world! 123"),
-            "Helloworld123"
+            "helloworld123"
         );
         assert_eq!(
             sanitize_process_type_name("This_is-a.test.123.abc"),
-            "This_is-a.test.123.abc"
+            "this-is-a-test-123-abc"
         );
         assert_eq!(
             sanitize_process_type_name("Special chars: !@#$%+^&*()"),
-            "Specialchars"
+            "specialchars"
         );
         assert_eq!(
             sanitize_process_type_name("Mixed: aBc123.xyz_-!@#"),
-            "MixedaBc123.xyz_-"
+            "mixedabc123-xyz"
         );
         assert_eq!(
             sanitize_process_type_name("Unicode: 日本語123"),
-            "Unicode123"
+            "unicode123"
         );
     }
 }

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -212,7 +212,9 @@ impl Buildpack for DotnetBuildpack {
                         //
                         // To guide users through the migration we'll write a notice when it may be
                         // relevant, e.g. when:
-                        // * We know the app is being built on Heroku (based on the `STACK` environment variable).
+                        // * We know the app is being built on Heroku based on the `STACK` environment
+                        //   variable, which is set when executing a classic/Cedar buildpack's `bin/compile`
+                        //   script (https://devcenter.heroku.com/articles/buildpack-api#stacks).
                         // * No Procfile is detected (so the user may have scaled dynos based on the old name).
                         // * Any launch processes, besides from `web`, were detected.
                         //

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -244,7 +244,7 @@ impl Buildpack for DotnetBuildpack {
                                 type names listed above.
                                 
                                 For more information on automatic process type detection, see:
-                                https://devcenter.heroku.com/articles/dotnet-behavior-in-heroku#automatic-process-type-detection."});
+                                https://devcenter.heroku.com/articles/dotnet-behavior-in-heroku#automatic-process-type-detection"});
                         }
                     }
                 }

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -223,7 +223,7 @@ impl Buildpack for DotnetBuildpack {
                         //
                         // For more info, see: https://github.com/heroku/buildpacks-dotnet/pull/252
                         //
-                        // TODO: Remove this notice in a few months when users have had a chance to see it,
+                        // TODO: Remove this warning in a few months when users have had a chance to see it,
                         // and make adjustments if/as needed.
                         if env::var("STACK").is_ok_and(|stack| stack.starts_with("heroku"))
                             && processes

--- a/buildpacks/dotnet/src/utils.rs
+++ b/buildpacks/dotnet/src/utils.rs
@@ -125,7 +125,7 @@ mod tests {
     fn test_truncates_to_63_characters() {
         let input = format!("a_b.c-d{}", "x".repeat(100));
         let result = to_rfc1123_label(&input).unwrap();
-        assert!(result.len() <= 63);
+        assert!(result.len() == 63);
     }
 
     #[test]

--- a/buildpacks/dotnet/src/utils.rs
+++ b/buildpacks/dotnet/src/utils.rs
@@ -67,18 +67,13 @@ pub(crate) fn to_rfc1123_label(input: &str) -> Result<String, &'static str> {
         }
     }
 
-    let label = label.trim_matches('-');
+    label = label.trim_matches('-').chars().take(63).collect();
 
     if label.is_empty() {
         return Err("label empty after sanitization");
     }
 
-    Ok(label
-        .chars()
-        .take(63)
-        .collect::<String>()
-        .trim_end_matches('-')
-        .to_string())
+    Ok(label)
 }
 
 #[cfg(test)]

--- a/buildpacks/dotnet/src/utils.rs
+++ b/buildpacks/dotnet/src/utils.rs
@@ -98,10 +98,6 @@ mod tests {
     #[test]
     fn test_lowercases_input() {
         assert_eq!(to_rfc1123_label("MiXeDCase").unwrap(), "mixedcase");
-        assert_eq!(
-            to_rfc1123_label("Mixed: aBc123.xyz_-!@#").unwrap(),
-            "mixed-abc123-xyz"
-        );
     }
 
     #[test]

--- a/buildpacks/dotnet/src/utils.rs
+++ b/buildpacks/dotnet/src/utils.rs
@@ -47,7 +47,7 @@ pub(crate) fn environment_as_sorted_vector(environment: &libcnb::Env) -> Vec<(&s
 ///
 /// Errors:
 /// Returns an error if sanitization results in an empty label.
-pub(crate) fn to_rfc1123_label(input: &str) -> Result<String, &'static str> {
+pub(crate) fn to_rfc1123_label(input: &str) -> Result<String, ()> {
     let mut label = String::new();
 
     let mut previous_char_was_hyphen = false;
@@ -68,11 +68,7 @@ pub(crate) fn to_rfc1123_label(input: &str) -> Result<String, &'static str> {
     }
 
     label = label.trim_matches('-').chars().take(63).collect();
-    if label.is_empty() {
-        Err("label empty after sanitization")
-    } else {
-        Ok(label)
-    }
+    if label.is_empty() { Err(()) } else { Ok(label) }
 }
 
 #[cfg(test)]

--- a/buildpacks/dotnet/src/utils.rs
+++ b/buildpacks/dotnet/src/utils.rs
@@ -121,7 +121,7 @@ mod tests {
     fn test_truncates_to_63_characters() {
         let input = format!("a_b.c-d{}", "x".repeat(100));
         let result = to_rfc1123_label(&input).unwrap();
-        assert!(result.len() == 63);
+        assert_eq!(result.len(), 63);
     }
 
     #[test]

--- a/buildpacks/dotnet/src/utils.rs
+++ b/buildpacks/dotnet/src/utils.rs
@@ -68,12 +68,11 @@ pub(crate) fn to_rfc1123_label(input: &str) -> Result<String, &'static str> {
     }
 
     label = label.trim_matches('-').chars().take(63).collect();
-
     if label.is_empty() {
-        return Err("label empty after sanitization");
+        Err("label empty after sanitization")
+    } else {
+        Ok(label)
     }
-
-    Ok(label)
 }
 
 #[cfg(test)]

--- a/buildpacks/dotnet/src/utils.rs
+++ b/buildpacks/dotnet/src/utils.rs
@@ -51,10 +51,10 @@ pub(crate) fn to_rfc1123_label(input: &str) -> Result<String, &'static str> {
     let mut label = String::new();
     let mut prev_was_hyphen = false;
 
-    for ch in input.chars().map(|c| c.to_ascii_lowercase()) {
-        match ch {
+    for char in input.chars().map(|c| c.to_ascii_lowercase()) {
+        match char {
             'a'..='z' | '0'..='9' => {
-                label.push(ch);
+                label.push(char);
                 prev_was_hyphen = false;
             }
             '-' | '.' | '_' | ' ' => {

--- a/buildpacks/dotnet/src/utils.rs
+++ b/buildpacks/dotnet/src/utils.rs
@@ -102,11 +102,7 @@ mod tests {
 
     #[test]
     fn test_replaces_separators_with_hyphen() {
-        assert_eq!(to_rfc1123_label("a.b_c d").unwrap(), "a-b-c-d");
-        assert_eq!(
-            to_rfc1123_label("This_is-a.test.123.abc").unwrap(),
-            "this-is-a-test-123-abc"
-        );
+        assert_eq!(to_rfc1123_label("a.b_c d-e").unwrap(), "a-b-c-d-e");
     }
 
     #[test]

--- a/buildpacks/dotnet/src/utils.rs
+++ b/buildpacks/dotnet/src/utils.rs
@@ -49,18 +49,18 @@ pub(crate) fn environment_as_sorted_vector(environment: &libcnb::Env) -> Vec<(&s
 /// Returns an error if sanitization results in an empty label.
 pub(crate) fn to_rfc1123_label(input: &str) -> Result<String, &'static str> {
     let mut label = String::new();
-    let mut prev_was_hyphen = false;
 
+    let mut previous_char_was_hyphen = false;
     for char in input.chars().map(|c| c.to_ascii_lowercase()) {
         match char {
             'a'..='z' | '0'..='9' => {
                 label.push(char);
-                prev_was_hyphen = false;
+                previous_char_was_hyphen = false;
             }
             '-' | '.' | '_' | ' ' => {
-                if !prev_was_hyphen {
+                if !previous_char_was_hyphen {
                     label.push('-');
-                    prev_was_hyphen = true;
+                    previous_char_was_hyphen = true;
                 }
             }
             _ => {}

--- a/buildpacks/dotnet/src/utils.rs
+++ b/buildpacks/dotnet/src/utils.rs
@@ -107,15 +107,7 @@ mod tests {
 
     #[test]
     fn test_removes_symbol_characters() {
-        assert_eq!(to_rfc1123_label("foo!@#bar&*()baz").unwrap(), "foobarbaz");
-        assert_eq!(
-            to_rfc1123_label("Unicode: 日本語123").unwrap(),
-            "unicode-123"
-        );
-        assert_eq!(
-            to_rfc1123_label("Special chars: !@#$%+^&*()").unwrap(),
-            "special-chars"
-        );
+        assert_eq!(to_rfc1123_label("foo!@#%^bar&*():日本").unwrap(), "foobar");
     }
 
     #[test]

--- a/buildpacks/dotnet/src/utils.rs
+++ b/buildpacks/dotnet/src/utils.rs
@@ -98,16 +98,32 @@ mod tests {
     #[test]
     fn test_lowercases_input() {
         assert_eq!(to_rfc1123_label("MiXeDCase").unwrap(), "mixedcase");
+        assert_eq!(
+            to_rfc1123_label("Mixed: aBc123.xyz_-!@#").unwrap(),
+            "mixed-abc123-xyz"
+        );
     }
 
     #[test]
     fn test_replaces_separators_with_hyphen() {
         assert_eq!(to_rfc1123_label("a.b_c d").unwrap(), "a-b-c-d");
+        assert_eq!(
+            to_rfc1123_label("This_is-a.test.123.abc").unwrap(),
+            "this-is-a-test-123-abc"
+        );
     }
 
     #[test]
     fn test_removes_symbol_characters() {
         assert_eq!(to_rfc1123_label("foo!@#bar&*()baz").unwrap(), "foobarbaz");
+        assert_eq!(
+            to_rfc1123_label("Unicode: 日本語123").unwrap(),
+            "unicode-123"
+        );
+        assert_eq!(
+            to_rfc1123_label("Special chars: !@#$%+^&*()").unwrap(),
+            "special-chars"
+        );
     }
 
     #[test]

--- a/buildpacks/dotnet/src/utils.rs
+++ b/buildpacks/dotnet/src/utils.rs
@@ -29,3 +29,117 @@ pub(crate) fn environment_as_sorted_vector(environment: &libcnb::Env) -> Vec<(&s
     result.sort_by_key(|kv| kv.0);
     result
 }
+
+/// Converts an arbitrary string slice into an RFC 1123-compliant DNS label.
+///
+/// RFC References:
+/// - RFC 1123 (section 2.1): Allows labels to start with letters or digits.
+/// - RFC 1035 (section 2.3.1): Defines allowed characters (`a-z`, `0-9`, `-`), maximum 63 characters.
+///
+/// Implementation Details:
+/// - Converts to lowercase (by convention, DNS is case-insensitive).
+/// - Keeps ASCII letters, digits, and hyphens.
+/// - Treats `.`, `_`, and space characters as separators, replacing them with hyphens.
+/// - Discards all other characters (e.g. `!`, `@`, `&`, `*`).
+/// - Collapses repeated hyphen-producing characters into a single hyphen.
+/// - Removes leading/trailing hyphens.
+/// - Truncates labels exceeding 63 characters.
+///
+/// Errors:
+/// Returns an error if sanitization results in an empty label.
+pub(crate) fn to_rfc1123_label(input: &str) -> Result<String, &'static str> {
+    let mut label = String::new();
+    let mut prev_was_hyphen = false;
+
+    for ch in input.chars().map(|c| c.to_ascii_lowercase()) {
+        match ch {
+            'a'..='z' | '0'..='9' => {
+                label.push(ch);
+                prev_was_hyphen = false;
+            }
+            '-' | '.' | '_' | ' ' => {
+                if !prev_was_hyphen {
+                    label.push('-');
+                    prev_was_hyphen = true;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let label = label.trim_matches('-');
+
+    if label.is_empty() {
+        return Err("label empty after sanitization");
+    }
+
+    Ok(label
+        .chars()
+        .take(63)
+        .collect::<String>()
+        .trim_end_matches('-')
+        .to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_allows_letters_digits_hyphen() {
+        assert_eq!(to_rfc1123_label("abc-123").unwrap(), "abc-123");
+    }
+
+    #[test]
+    fn test_allows_leading_digits() {
+        assert_eq!(to_rfc1123_label("123label").unwrap(), "123label");
+    }
+
+    #[test]
+    fn test_lowercases_input() {
+        assert_eq!(to_rfc1123_label("MiXeDCase").unwrap(), "mixedcase");
+    }
+
+    #[test]
+    fn test_replaces_separators_with_hyphen() {
+        assert_eq!(to_rfc1123_label("a.b_c d").unwrap(), "a-b-c-d");
+    }
+
+    #[test]
+    fn test_removes_symbol_characters() {
+        assert_eq!(to_rfc1123_label("foo!@#bar&*()baz").unwrap(), "foobarbaz");
+    }
+
+    #[test]
+    fn test_collapses_multiple_separator_chars() {
+        assert_eq!(to_rfc1123_label("a__b..c  d").unwrap(), "a-b-c-d");
+    }
+
+    #[test]
+    fn test_trims_leading_and_trailing_hyphens() {
+        assert_eq!(to_rfc1123_label("--abc--").unwrap(), "abc");
+        assert_eq!(to_rfc1123_label("...abc...").unwrap(), "abc");
+    }
+
+    #[test]
+    fn test_truncates_to_63_characters() {
+        let input = format!("a_b.c-d{}", "x".repeat(100));
+        let result = to_rfc1123_label(&input).unwrap();
+        assert!(result.len() <= 63);
+    }
+
+    #[test]
+    fn test_removes_trailing_hyphen_after_truncation() {
+        let input = format!("{}_", "a".repeat(70));
+        let result = to_rfc1123_label(&input).unwrap();
+        assert!(result.len() <= 63);
+        assert!(!result.ends_with('-'));
+    }
+
+    #[test]
+    fn test_errors_on_empty_label() {
+        assert!(to_rfc1123_label("").is_err());
+        assert!(to_rfc1123_label("!!!").is_err());
+        assert!(to_rfc1123_label("###@@@%%%").is_err());
+    }
+}

--- a/buildpacks/dotnet/src/utils.rs
+++ b/buildpacks/dotnet/src/utils.rs
@@ -67,7 +67,13 @@ pub(crate) fn to_rfc1123_label(input: &str) -> Result<String, ()> {
         }
     }
 
-    label = label.trim_matches('-').chars().take(63).collect();
+    label = label
+        .trim_matches('-')
+        .chars()
+        .take(63)
+        .collect::<String>()
+        .trim_end_matches('-')
+        .to_string();
     if label.is_empty() { Err(()) } else { Ok(label) }
 }
 
@@ -120,9 +126,9 @@ mod tests {
 
     #[test]
     fn test_removes_trailing_hyphen_after_truncation() {
-        let input = format!("{}_", "a".repeat(70));
+        let input = format!("{}-aaaaaaa", "a".repeat(62));
         let result = to_rfc1123_label(&input).unwrap();
-        assert!(result.len() <= 63);
+        assert_eq!(result.len(), 62);
         assert!(!result.ends_with('-'));
     }
 

--- a/buildpacks/dotnet/tests/dotnet_publish_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_publish_test.rs
@@ -246,7 +246,7 @@ fn test_dotnet_publish_with_updated_process_type_name_heroku_warning() {
                       type names listed above.
                       
                       For more information on automatic process type detection, see:
-                      https://devcenter.heroku.com/articles/dotnet-behavior-in-heroku#automatic-process-type-detection.
+                      https://devcenter.heroku.com/articles/dotnet-behavior-in-heroku#automatic-process-type-detection
                   - Done"}
             );
             assert_contains!(context.pack_stdout, "web -> /workspace/web/bin/publish/");

--- a/buildpacks/dotnet/tests/dotnet_publish_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_publish_test.rs
@@ -1,6 +1,8 @@
 use crate::tests::{default_build_config, get_dotnet_arch};
 use indoc::{formatdoc, indoc};
-use libcnb_test::{ContainerConfig, PackResult, TestRunner, assert_contains, assert_empty};
+use libcnb_test::{
+    ContainerConfig, PackResult, TestRunner, assert_contains, assert_empty, assert_not_contains,
+};
 use regex::Regex;
 
 #[test]
@@ -122,7 +124,8 @@ fn test_dotnet_publish_process_registration_without_procfile() {
                   - Detecting process types from published artifacts
                   - Found `web`: bash -c cd bin/publish; ./foo --urls http://*:$PORT
                   - No Procfile detected
-                  - Registering detected process types as launch processes"}
+                  - Registering detected process types as launch processes
+                - Done"}
             );
         },
     );
@@ -196,6 +199,11 @@ fn test_dotnet_publish_with_space_in_project_filename() {
             assert_contains!(
                 &context.pack_stdout,
                 r"Found `console-app`: bash -c cd 'console app/bin/publish'; ./'console app'"
+            );
+
+            assert_not_contains!(
+                &context.pack_stdout,
+                r"Auto-detected process type names were recently changed"
             );
 
             context.start_container(

--- a/buildpacks/dotnet/tests/dotnet_publish_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_publish_test.rs
@@ -195,11 +195,11 @@ fn test_dotnet_publish_with_space_in_project_filename() {
 
             assert_contains!(
                 &context.pack_stdout,
-                r"Found `consoleapp`: bash -c cd 'console app/bin/publish'; ./'console app'"
+                r"Found `console-app`: bash -c cd 'console app/bin/publish'; ./'console app'"
             );
 
             context.start_container(
-                ContainerConfig::new().entrypoint("consoleapp"),
+                ContainerConfig::new().entrypoint("console-app"),
                 |container| {
                     let log_output = container.logs_wait();
 


### PR DESCRIPTION
This PR changes dynamically generated process type names to be compliant with the [RFC 1123](https://datatracker.ietf.org/doc/html/rfc1123) DNS label spec, Kubernetes, as well as Cedar, by:

* Lower-casing all letters (for compatibility with [Kubernetes DNS label names](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names)).
* Treating space characters as a "separator", replacing them with hyphens. Previously, spaces were simply discarded.
* Treating `.` as a "separator", replacing them with hyphens (for compatibility with Cedar/classic buildpack, which doesn't allow process types with dots). Previously, dots were included in the process type.
* Replacing `_` with `-`. Previously, underscores were included in the process type.
* Truncating the process type to 63 characters (since we're replacing dots with hyphens to adhere to the label spec).
* Ensuring that process types start and end with either a digit or letter.

A new helper function, `utils::to_rfc1123_label` replaces `launch_process::sanitize_process_type_name` for normalizing process types. The doc comment for the new function includes relevant RFC references and specific implementation details.

As this is a breaking change for Heroku customers who may rely on this functionality, a notice is printed to the output when changes may be necessary - while background workers may be removed as a result of this renaming on Cedar, it won't affect customers using a `Procfile` or apps with only a single web project. I've tried to limit the scenarios where this message will be written to avoid unnecessary confusion. Let me know if this logic/approach can be improved though!

The [Dev Center article listed](https://devcenter.heroku.com/articles/dotnet-behavior-in-heroku#automatic-process-type-detection) in the notice should be updated immediately after this change is incorporated in the classic .NET buildpack to reflect the updated process type naming approach.

GUS-W-18216563