### PR TITLE
Increase test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 .DS_Store
 packaged/
+mutants*

--- a/buildpacks/dotnet/src/dotnet/global_json.rs
+++ b/buildpacks/dotnet/src/dotnet/global_json.rs
@@ -135,11 +135,7 @@ mod tests {
                 roll_forward: case.roll_forward.map(ToString::to_string),
             };
             let result = VersionReq::try_from(sdk_config).unwrap();
-            assert_eq!(
-                result.to_string(),
-                case.expected,
-                "Failed for case: {case:?}"
-            );
+            assert_eq!(result.to_string(), case.expected);
         }
     }
 

--- a/buildpacks/dotnet/src/dotnet/project.rs
+++ b/buildpacks/dotnet/src/dotnet/project.rs
@@ -453,4 +453,30 @@ mod tests {
         assert_eq!(project.assembly_name, "MyConsoleApp");
         assert_eq!(project.path, project_path);
     }
+
+    #[test]
+    fn test_load_project_without_assembly_name() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let project_path = temp_dir.path().join("ConsoleApp.csproj");
+        fs::write(
+            &project_path,
+            r#"
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <OutputType>Exe</OutputType>
+    </PropertyGroup>
+</Project>"#,
+        )
+        .unwrap();
+
+        let project = Project::load_from_path(&project_path).unwrap();
+        assert_eq!(project.target_framework, "net6.0");
+        assert_eq!(project.project_type, ProjectType::ConsoleApplication);
+        assert_eq!(
+            project.assembly_name,
+            project_path.file_stem().unwrap().to_string_lossy()
+        );
+        assert_eq!(project.path, project_path);
+    }
 }

--- a/buildpacks/dotnet/src/dotnet/project.rs
+++ b/buildpacks/dotnet/src/dotnet/project.rs
@@ -413,4 +413,20 @@ mod tests {
         };
         assert_eq!(infer_project_type(&metadata), ProjectType::Unknown);
     }
+
+    #[test]
+    fn test_load_project_missing_target_framework() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let project_path = temp_dir.path().join("test.csproj");
+        fs::write(
+            &project_path,
+            r#"
+<Project Sdk="Microsoft.NET.Sdk">
+</Project>"#,
+        )
+        .unwrap();
+
+        let result = Project::load_from_path(&project_path);
+        assert!(matches!(result, Err(LoadError::MissingTargetFramework(_))));
+    }
 }

--- a/buildpacks/dotnet/src/dotnet/project.rs
+++ b/buildpacks/dotnet/src/dotnet/project.rs
@@ -93,7 +93,7 @@ fn parse_metadata(document: &Document) -> Metadata {
             }
             "AssemblyName" => {
                 if let Some(text) = node.text() {
-                    if !text.is_empty() {
+                    if !text.trim().is_empty() {
                         metadata.assembly_name = Some(text.to_string());
                     }
                 }
@@ -353,5 +353,31 @@ mod tests {
             assembly_name: None,
         };
         assert_eq!(infer_project_type(&metadata), ProjectType::Unknown);
+    }
+
+    #[test]
+    fn test_parse_project_with_empty_assembly_name() {
+        let project_xml = r#"
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <AssemblyName></AssemblyName>
+    </PropertyGroup>
+</Project>
+"#;
+        assert_metadata(project_xml, Some("Microsoft.NET.Sdk"), "net6.0", None, None);
+    }
+
+    #[test]
+    fn test_parse_project_with_whitespace_assembly_name() {
+        let project_xml = r#"
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <AssemblyName>  </AssemblyName>
+    </PropertyGroup>
+</Project>
+"#;
+        assert_metadata(project_xml, Some("Microsoft.NET.Sdk"), "net6.0", None, None);
     }
 }

--- a/buildpacks/dotnet/src/dotnet/project.rs
+++ b/buildpacks/dotnet/src/dotnet/project.rs
@@ -356,6 +356,18 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_project_with_empty_target_framework() {
+        let project_xml = r#"
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework></TargetFramework>
+    </PropertyGroup>
+</Project>
+"#;
+        assert_metadata(project_xml, Some("Microsoft.NET.Sdk"), "", None, None);
+    }
+
+    #[test]
     fn test_parse_project_with_empty_assembly_name() {
         let project_xml = r#"
 <Project Sdk="Microsoft.NET.Sdk">

--- a/buildpacks/dotnet/src/dotnet/project.rs
+++ b/buildpacks/dotnet/src/dotnet/project.rs
@@ -429,4 +429,28 @@ mod tests {
         let result = Project::load_from_path(&project_path);
         assert!(matches!(result, Err(LoadError::MissingTargetFramework(_))));
     }
+
+    #[test]
+    fn test_load_project_with_assembly_name() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let project_path = temp_dir.path().join("ConsoleApp.csproj");
+        fs::write(
+            &project_path,
+            r#"
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <OutputType>Exe</OutputType>
+        <AssemblyName>MyConsoleApp</AssemblyName>
+    </PropertyGroup>
+</Project>"#,
+        )
+        .unwrap();
+
+        let project = Project::load_from_path(&project_path).unwrap();
+        assert_eq!(project.target_framework, "net6.0");
+        assert_eq!(project.project_type, ProjectType::ConsoleApplication);
+        assert_eq!(project.assembly_name, "MyConsoleApp");
+        assert_eq!(project.path, project_path);
+    }
 }

--- a/buildpacks/dotnet/src/dotnet/project.rs
+++ b/buildpacks/dotnet/src/dotnet/project.rs
@@ -380,4 +380,37 @@ mod tests {
 "#;
         assert_metadata(project_xml, Some("Microsoft.NET.Sdk"), "net6.0", None, None);
     }
+
+    #[test]
+    fn test_infer_project_type_unknown_sdk_with_exe() {
+        let metadata = Metadata {
+            sdk_id: Some("Unknown.Sdk".to_string()),
+            target_framework: "net6.0".to_string(),
+            output_type: Some("Exe".to_string()),
+            assembly_name: None,
+        };
+        assert_eq!(infer_project_type(&metadata), ProjectType::Unknown);
+    }
+
+    #[test]
+    fn test_infer_project_type_net_sdk_without_exe() {
+        let metadata = Metadata {
+            sdk_id: Some("Microsoft.NET.Sdk".to_string()),
+            target_framework: "net6.0".to_string(),
+            output_type: Some("Library".to_string()),
+            assembly_name: None,
+        };
+        assert_eq!(infer_project_type(&metadata), ProjectType::Unknown);
+    }
+
+    #[test]
+    fn test_infer_project_type_no_sdk() {
+        let metadata = Metadata {
+            sdk_id: None,
+            target_framework: "net6.0".to_string(),
+            output_type: Some("Exe".to_string()),
+            assembly_name: None,
+        };
+        assert_eq!(infer_project_type(&metadata), ProjectType::Unknown);
+    }
 }

--- a/buildpacks/dotnet/src/dotnet/runtime_identifier.rs
+++ b/buildpacks/dotnet/src/dotnet/runtime_identifier.rs
@@ -36,6 +36,14 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_runtime_identifier_display() {
+        assert_eq!(RuntimeIdentifier::LinuxX64.to_string(), "linux-x64");
+        assert_eq!(RuntimeIdentifier::LinuxArm64.to_string(), "linux-arm64");
+        assert_eq!(RuntimeIdentifier::OsxX64.to_string(), "osx-x64");
+        assert_eq!(RuntimeIdentifier::OsxArm64.to_string(), "osx-arm64");
+    }
+
+    #[test]
     fn test_get_runtime_identifier() {
         assert_eq!(
             get_runtime_identifier(Os::Linux, Arch::Amd64),

--- a/buildpacks/dotnet/src/dotnet/runtime_identifier.rs
+++ b/buildpacks/dotnet/src/dotnet/runtime_identifier.rs
@@ -30,3 +30,28 @@ pub(crate) fn get_runtime_identifier(os: Os, arch: Arch) -> RuntimeIdentifier {
         (Os::Darwin, Arch::Arm64) => RuntimeIdentifier::OsxArm64,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_runtime_identifier() {
+        assert_eq!(
+            get_runtime_identifier(Os::Linux, Arch::Amd64),
+            RuntimeIdentifier::LinuxX64
+        );
+        assert_eq!(
+            get_runtime_identifier(Os::Linux, Arch::Arm64),
+            RuntimeIdentifier::LinuxArm64
+        );
+        assert_eq!(
+            get_runtime_identifier(Os::Darwin, Arch::Amd64),
+            RuntimeIdentifier::OsxX64
+        );
+        assert_eq!(
+            get_runtime_identifier(Os::Darwin, Arch::Arm64),
+            RuntimeIdentifier::OsxArm64
+        );
+    }
+}

--- a/buildpacks/dotnet/src/dotnet/solution.rs
+++ b/buildpacks/dotnet/src/dotnet/solution.rs
@@ -170,4 +170,71 @@ mod tests {
             "ProjectWithParams/ProjectWithParams.csproj"
         );
     }
+
+    #[test]
+    fn test_load_from_path_success() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let solution_path = temp_dir.path().join("test.sln");
+        let project1_dir = temp_dir.path().join("Project1");
+        let project2_dir = temp_dir.path().join("Project2");
+        fs::create_dir(&project1_dir).unwrap();
+        fs::create_dir(&project2_dir).unwrap();
+
+        // Create solution file
+        let solution_content = r#"
+        Microsoft Visual Studio Solution File, Format Version 12.00
+        Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project1", "Project1\Project1.csproj", "{8C28B63A-F94D-4A0B-A2B0-6DC6E1B88264}"
+        EndProject
+        Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project2", "Project2\Project2.csproj", "{FEA4E2C3-9F8E-4A2C-88C9-1E6E41F8B9AD}"
+        EndProject
+        "#;
+        fs::write(&solution_path, solution_content).unwrap();
+
+        let project_content = r#"
+        <Project Sdk="Microsoft.NET.Sdk">
+            <PropertyGroup>
+                <TargetFramework>net6.0</TargetFramework>
+            </PropertyGroup>
+        </Project>"#;
+        fs::write(project1_dir.join("Project1.csproj"), project_content).unwrap();
+        fs::write(project2_dir.join("Project2.csproj"), project_content).unwrap();
+
+        let solution = Solution::load_from_path(&solution_path).unwrap();
+
+        assert_eq!(solution.path, solution_path);
+        assert_eq!(solution.projects.len(), 2);
+        assert_eq!(
+            solution.projects[0].path,
+            project1_dir.join("Project1.csproj")
+        );
+        assert_eq!(
+            solution.projects[1].path,
+            project2_dir.join("Project2.csproj")
+        );
+    }
+
+    #[test]
+    fn test_load_from_path_missing_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let non_existent_path = temp_dir.path().join("nonexistent.sln");
+
+        let result = Solution::load_from_path(&non_existent_path);
+        assert!(matches!(result, Err(LoadError::ReadSolutionFile(_))));
+    }
+
+    #[test]
+    fn test_load_from_path_missing_project() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let solution_path = temp_dir.path().join("test.sln");
+
+        let solution_content = r#"
+        Microsoft Visual Studio Solution File, Format Version 12.00
+        Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project1", "Project1\Project1.csproj", "{8C28B63A-F94D-4A0B-A2B0-6DC6E1B88264}"
+        EndProject
+        "#;
+        fs::write(&solution_path, solution_content).unwrap();
+
+        let result = Solution::load_from_path(&solution_path);
+        assert!(matches!(result, Err(LoadError::LoadProject(_))));
+    }
 }

--- a/buildpacks/dotnet/src/dotnet/solution.rs
+++ b/buildpacks/dotnet/src/dotnet/solution.rs
@@ -237,4 +237,25 @@ mod tests {
         let result = Solution::load_from_path(&solution_path);
         assert!(matches!(result, Err(LoadError::LoadProject(_))));
     }
+
+    #[test]
+    fn test_ephemeral_solution() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let project_path = temp_dir.path().join("test.csproj");
+
+        let project_content = r#"
+        <Project Sdk="Microsoft.NET.Sdk">
+            <PropertyGroup>
+                <TargetFramework>net6.0</TargetFramework>
+            </PropertyGroup>
+        </Project>"#;
+        fs::write(&project_path, project_content).unwrap();
+
+        let project = Project::load_from_path(&project_path).unwrap();
+        let solution = Solution::ephemeral(project);
+
+        assert_eq!(solution.path, project_path);
+        assert_eq!(solution.projects.len(), 1);
+        assert_eq!(solution.projects[0].path, project_path);
+    }
 }

--- a/buildpacks/dotnet/src/dotnet/solution.rs
+++ b/buildpacks/dotnet/src/dotnet/solution.rs
@@ -58,10 +58,16 @@ fn extract_project_references(contents: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
-    #[test]
-    fn test_extract_project_references() {
-        let solution_content = r#"
+    const SIMPLE_PROJECT_CONTENT: &str = r#"
+        <Project Sdk="Microsoft.NET.Sdk">
+            <PropertyGroup>
+                <TargetFramework>net6.0</TargetFramework>
+            </PropertyGroup>
+        </Project>"#;
+
+    const SOLUTION_WITH_TWO_PROJECTS: &str = r#"
         Microsoft Visual Studio Solution File, Format Version 12.00
         # Visual Studio Version 16
         VisualStudioVersion = 16.0.28729.10
@@ -78,7 +84,17 @@ mod tests {
         EndGlobal
         "#;
 
-        let project_references = extract_project_references(solution_content);
+    fn create_test_project(temp_dir: &tempfile::TempDir, project_name: &str) -> PathBuf {
+        let project_dir = temp_dir.path().join(project_name);
+        fs::create_dir(&project_dir).unwrap();
+        let project_path = project_dir.join(format!("{project_name}.csproj"));
+        fs::write(&project_path, SIMPLE_PROJECT_CONTENT).unwrap();
+        project_path
+    }
+
+    #[test]
+    fn test_extract_project_references_should_find_all_projects_in_solution() {
+        let project_references = extract_project_references(SOLUTION_WITH_TWO_PROJECTS);
 
         assert_eq!(project_references.len(), 2);
         assert_eq!(project_references[0], "Project1/Project1.csproj");
@@ -86,7 +102,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_project_references_with_no_projects() {
+    fn test_extract_project_references_should_return_empty_vec_for_solution_with_no_projects() {
         let solution_content = r"
         Microsoft Visual Studio Solution File, Format Version 12.00
         # Visual Studio Version 16
@@ -101,12 +117,11 @@ mod tests {
         ";
 
         let project_references = extract_project_references(solution_content);
-
         assert_eq!(project_references.len(), 0);
     }
 
     #[test]
-    fn test_extract_project_references_with_solution_folder() {
+    fn test_extract_project_references_should_ignore_solution_folders() {
         let solution_content = r#"
         Microsoft Visual Studio Solution File, Format Version 12.00
         # Visual Studio Version 16
@@ -125,8 +140,6 @@ mod tests {
         "#;
 
         let project_references = extract_project_references(solution_content);
-
-        // Expect only the actual project path
         assert_eq!(project_references.len(), 1);
         assert_eq!(
             project_references[0],
@@ -135,7 +148,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_project_references_with_solution_items() {
+    fn test_extract_project_references_should_ignore_solution_items() {
         let solution_content = r#"
         Microsoft Visual Studio Solution File, Format Version 12.00
         # Visual Studio Version 16
@@ -162,8 +175,6 @@ mod tests {
         "#;
 
         let project_references = extract_project_references(solution_content);
-
-        // Expect only the actual project path
         assert_eq!(project_references.len(), 1);
         assert_eq!(
             project_references[0],
@@ -172,49 +183,24 @@ mod tests {
     }
 
     #[test]
-    fn test_load_from_path_success() {
+    fn test_load_from_path_should_load_all_projects_in_solution() {
         let temp_dir = tempfile::tempdir().unwrap();
         let solution_path = temp_dir.path().join("test.sln");
-        let project1_dir = temp_dir.path().join("Project1");
-        let project2_dir = temp_dir.path().join("Project2");
-        fs::create_dir(&project1_dir).unwrap();
-        fs::create_dir(&project2_dir).unwrap();
 
-        // Create solution file
-        let solution_content = r#"
-        Microsoft Visual Studio Solution File, Format Version 12.00
-        Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project1", "Project1\Project1.csproj", "{8C28B63A-F94D-4A0B-A2B0-6DC6E1B88264}"
-        EndProject
-        Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project2", "Project2\Project2.csproj", "{FEA4E2C3-9F8E-4A2C-88C9-1E6E41F8B9AD}"
-        EndProject
-        "#;
-        fs::write(&solution_path, solution_content).unwrap();
-
-        let project_content = r#"
-        <Project Sdk="Microsoft.NET.Sdk">
-            <PropertyGroup>
-                <TargetFramework>net6.0</TargetFramework>
-            </PropertyGroup>
-        </Project>"#;
-        fs::write(project1_dir.join("Project1.csproj"), project_content).unwrap();
-        fs::write(project2_dir.join("Project2.csproj"), project_content).unwrap();
+        fs::write(&solution_path, SOLUTION_WITH_TWO_PROJECTS).unwrap();
+        let project1_path = create_test_project(&temp_dir, "Project1");
+        let project2_path = create_test_project(&temp_dir, "Project2");
 
         let solution = Solution::load_from_path(&solution_path).unwrap();
 
         assert_eq!(solution.path, solution_path);
         assert_eq!(solution.projects.len(), 2);
-        assert_eq!(
-            solution.projects[0].path,
-            project1_dir.join("Project1.csproj")
-        );
-        assert_eq!(
-            solution.projects[1].path,
-            project2_dir.join("Project2.csproj")
-        );
+        assert_eq!(solution.projects[0].path, project1_path);
+        assert_eq!(solution.projects[1].path, project2_path);
     }
 
     #[test]
-    fn test_load_from_path_missing_file() {
+    fn test_load_from_path_should_return_error_when_solution_file_does_not_exist() {
         let temp_dir = tempfile::tempdir().unwrap();
         let non_existent_path = temp_dir.path().join("nonexistent.sln");
 
@@ -223,7 +209,7 @@ mod tests {
     }
 
     #[test]
-    fn test_load_from_path_missing_project() {
+    fn test_load_from_path_should_return_error_when_project_file_does_not_exist() {
         let temp_dir = tempfile::tempdir().unwrap();
         let solution_path = temp_dir.path().join("test.sln");
 
@@ -239,18 +225,9 @@ mod tests {
     }
 
     #[test]
-    fn test_ephemeral_solution() {
+    fn test_ephemeral_solution_should_contain_single_project() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let project_path = temp_dir.path().join("test.csproj");
-
-        let project_content = r#"
-        <Project Sdk="Microsoft.NET.Sdk">
-            <PropertyGroup>
-                <TargetFramework>net6.0</TargetFramework>
-            </PropertyGroup>
-        </Project>"#;
-        fs::write(&project_path, project_content).unwrap();
-
+        let project_path = create_test_project(&temp_dir, "test");
         let project = Project::load_from_path(&project_path).unwrap();
         let solution = Solution::ephemeral(project);
 

--- a/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
+++ b/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
@@ -19,16 +19,11 @@ impl FromStr for TargetFrameworkMoniker {
     fn from_str(tfm: &str) -> Result<Self, Self::Err> {
         let supported_prefix = "net";
 
-        if tfm.len() < 3 {
+        if !tfm.starts_with(supported_prefix) {
             return Err(ParseTargetFrameworkError::InvalidFormat(tfm.to_string()));
         }
 
-        let prefix = &tfm[..3];
         let rest = &tfm[3..];
-
-        if !supported_prefix.contains(prefix) {
-            return Err(ParseTargetFrameworkError::InvalidFormat(tfm.to_string()));
-        }
 
         let parts: Vec<&str> = rest.split('-').collect();
         if parts.len() > 1 {

--- a/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
+++ b/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
@@ -17,7 +17,7 @@ impl FromStr for TargetFrameworkMoniker {
     type Err = ParseTargetFrameworkError;
 
     fn from_str(tfm: &str) -> Result<Self, Self::Err> {
-        let valid_prefixes = ["net"];
+        let supported_prefixes = ["net"];
 
         if tfm.len() < 3 {
             return Err(ParseTargetFrameworkError::InvalidFormat(tfm.to_string()));
@@ -26,7 +26,7 @@ impl FromStr for TargetFrameworkMoniker {
         let prefix = &tfm[..3];
         let rest = &tfm[3..];
 
-        if !valid_prefixes.contains(&prefix) {
+        if !supported_prefixes.contains(&prefix) {
             return Err(ParseTargetFrameworkError::InvalidFormat(tfm.to_string()));
         }
 
@@ -124,7 +124,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_invalid_prefix_only() {
+    fn test_parse_unsupported_prefix_only() {
         let tfm = "foo".to_string();
         assert_eq!(
             tfm.parse::<TargetFrameworkMoniker>(),

--- a/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
+++ b/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
@@ -124,6 +124,15 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_invalid_prefix_only() {
+        let tfm = "foo".to_string();
+        assert_eq!(
+            tfm.parse::<TargetFrameworkMoniker>(),
+            Err(ParseTargetFrameworkError::InvalidFormat(tfm))
+        );
+    }
+
+    #[test]
     fn test_parse_unsupported_os() {
         let tfm = "net6.0-ios15.0".to_string();
         assert_eq!(

--- a/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
+++ b/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
@@ -111,6 +111,13 @@ mod tests {
         assert!(matches!(
             tfm.parse::<TargetFrameworkMoniker>(),
             Err(ParseTargetFrameworkError::InvalidFormat(_))
+
+    #[test]
+    fn test_parse_invalid_no_version() {
+        let tfm = "net";
+        assert!(matches!(
+            tfm.parse::<TargetFrameworkMoniker>(),
+            Err(ParseTargetFrameworkError::InvalidFormat(s))
         ));
     }
 

--- a/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
+++ b/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
@@ -23,7 +23,7 @@ impl FromStr for TargetFrameworkMoniker {
             return Err(ParseTargetFrameworkError::InvalidFormat(tfm.to_string()));
         }
 
-        let rest = &tfm[3..];
+        let rest = &tfm[SUPPORTED_PREFIX.len()..];
 
         let parts: Vec<&str> = rest.split('-').collect();
         if parts.len() > 1 {

--- a/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
+++ b/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
@@ -89,10 +89,10 @@ mod tests {
 
     #[test]
     fn test_parse_invalid_empty() {
-        let tfm = "";
+        let tfm = String::new();
         assert_eq!(
             tfm.parse::<TargetFrameworkMoniker>(),
-            Err(ParseTargetFrameworkError::InvalidFormat(tfm.to_string()))
+            Err(ParseTargetFrameworkError::InvalidFormat(tfm))
         );
     }
 
@@ -101,34 +101,34 @@ mod tests {
         let tfm = String::from("netcoreapp");
         assert_eq!(
             tfm.parse::<TargetFrameworkMoniker>(),
-            Err(ParseTargetFrameworkError::InvalidFormat(tfm.to_string()))
+            Err(ParseTargetFrameworkError::InvalidFormat(tfm))
         );
     }
 
     #[test]
     fn test_parse_invalid_malformed_version() {
-        let tfm = "net6.x";
+        let tfm = "net6.x".to_string();
         assert_eq!(
             tfm.parse::<TargetFrameworkMoniker>(),
-            Err(ParseTargetFrameworkError::InvalidFormat(tfm.to_string()))
+            Err(ParseTargetFrameworkError::InvalidFormat(tfm))
         );
     }
 
     #[test]
     fn test_parse_invalid_no_version() {
-        let tfm = "net";
+        let tfm = "net".to_string();
         assert_eq!(
             tfm.parse::<TargetFrameworkMoniker>(),
-            Err(ParseTargetFrameworkError::InvalidFormat(tfm.to_string()))
+            Err(ParseTargetFrameworkError::InvalidFormat(tfm))
         );
     }
 
     #[test]
     fn test_parse_unsupported_os() {
-        let tfm = "net6.0-ios15.0";
+        let tfm = "net6.0-ios15.0".to_string();
         assert_eq!(
             tfm.parse::<TargetFrameworkMoniker>(),
-            Err(ParseTargetFrameworkError::UnsupportedOSTfm(tfm.to_string()))
+            Err(ParseTargetFrameworkError::UnsupportedOSTfm(tfm))
         );
     }
 }

--- a/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
+++ b/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
@@ -13,13 +13,13 @@ pub(crate) struct TargetFrameworkMoniker {
     pub(crate) version_part: String,
 }
 
+const SUPPORTED_PREFIX: &str = "net";
+
 impl FromStr for TargetFrameworkMoniker {
     type Err = ParseTargetFrameworkError;
 
     fn from_str(tfm: &str) -> Result<Self, Self::Err> {
-        let supported_prefix = "net";
-
-        if !tfm.starts_with(supported_prefix) {
+        if !tfm.starts_with(SUPPORTED_PREFIX) {
             return Err(ParseTargetFrameworkError::InvalidFormat(tfm.to_string()));
         }
 

--- a/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
+++ b/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
@@ -110,24 +110,6 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_invalid_no_version() {
-        let tfm = "net".to_string();
-        assert_eq!(
-            tfm.parse::<TargetFrameworkMoniker>(),
-            Err(ParseTargetFrameworkError::InvalidFormat(tfm))
-        );
-    }
-
-    #[test]
-    fn test_parse_unsupported_prefix_only() {
-        let tfm = "foo".to_string();
-        assert_eq!(
-            tfm.parse::<TargetFrameworkMoniker>(),
-            Err(ParseTargetFrameworkError::InvalidFormat(tfm))
-        );
-    }
-
-    #[test]
     fn test_parse_unsupported_os() {
         let tfm = "net6.0-ios15.0".to_string();
         assert_eq!(

--- a/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
+++ b/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
@@ -26,7 +26,7 @@ impl FromStr for TargetFrameworkMoniker {
         let prefix = &tfm[..3];
         let rest = &tfm[3..];
 
-        if !valid_prefixes.contains(&prefix) || rest.is_empty() {
+        if !valid_prefixes.contains(&prefix) {
             return Err(ParseTargetFrameworkError::InvalidFormat(tfm.to_string()));
         }
 

--- a/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
+++ b/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
@@ -2,13 +2,13 @@ use semver::VersionReq;
 use std::convert::TryFrom;
 use std::str::FromStr;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) enum ParseTargetFrameworkError {
     InvalidFormat(String),
     UnsupportedOSTfm(String),
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) struct TargetFrameworkMoniker {
     pub(crate) version_part: String,
 }
@@ -90,45 +90,45 @@ mod tests {
     #[test]
     fn test_parse_invalid_empty() {
         let tfm = "";
-        assert!(matches!(
+        assert_eq!(
             tfm.parse::<TargetFrameworkMoniker>(),
-            Err(ParseTargetFrameworkError::InvalidFormat(s)) if s == *tfm
-        ));
+            Err(ParseTargetFrameworkError::InvalidFormat(tfm.to_string()))
+        );
     }
 
     #[test]
     fn test_parse_invalid_non_numeric() {
         let tfm = String::from("netcoreapp");
-        assert!(matches!(
+        assert_eq!(
             tfm.parse::<TargetFrameworkMoniker>(),
-            Err(ParseTargetFrameworkError::InvalidFormat(s)) if s == *tfm
-        ));
+            Err(ParseTargetFrameworkError::InvalidFormat(tfm.to_string()))
+        );
     }
 
     #[test]
     fn test_parse_invalid_malformed_version() {
         let tfm = "net6.x";
-        assert!(matches!(
+        assert_eq!(
             tfm.parse::<TargetFrameworkMoniker>(),
-            Err(ParseTargetFrameworkError::InvalidFormat(s)) if s == *tfm
-        ));
+            Err(ParseTargetFrameworkError::InvalidFormat(tfm.to_string()))
+        );
     }
 
     #[test]
     fn test_parse_invalid_no_version() {
         let tfm = "net";
-        assert!(matches!(
+        assert_eq!(
             tfm.parse::<TargetFrameworkMoniker>(),
-            Err(ParseTargetFrameworkError::InvalidFormat(s)) if s == *tfm
-        ));
+            Err(ParseTargetFrameworkError::InvalidFormat(tfm.to_string()))
+        );
     }
 
     #[test]
     fn test_parse_unsupported_os() {
         let tfm = "net6.0-ios15.0";
-        assert!(matches!(
+        assert_eq!(
             tfm.parse::<TargetFrameworkMoniker>(),
-            Err(ParseTargetFrameworkError::UnsupportedOSTfm(s)) if s == *tfm
-        ));
+            Err(ParseTargetFrameworkError::UnsupportedOSTfm(tfm.to_string()))
+        );
     }
 }

--- a/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
+++ b/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
@@ -19,7 +19,7 @@ impl FromStr for TargetFrameworkMoniker {
     fn from_str(tfm: &str) -> Result<Self, Self::Err> {
         let valid_prefixes = ["net"];
 
-        if tfm.len() < 4 {
+        if tfm.len() < 3 {
             return Err(ParseTargetFrameworkError::InvalidFormat(tfm.to_string()));
         }
 

--- a/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
+++ b/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
@@ -92,7 +92,7 @@ mod tests {
         let tfm = "";
         assert!(matches!(
             tfm.parse::<TargetFrameworkMoniker>(),
-            Err(ParseTargetFrameworkError::InvalidFormat(_))
+            Err(ParseTargetFrameworkError::InvalidFormat(s)) if s == *tfm
         ));
     }
 
@@ -101,7 +101,7 @@ mod tests {
         let tfm = String::from("netcoreapp");
         assert!(matches!(
             tfm.parse::<TargetFrameworkMoniker>(),
-            Err(ParseTargetFrameworkError::InvalidFormat(_))
+            Err(ParseTargetFrameworkError::InvalidFormat(s)) if s == *tfm
         ));
     }
 
@@ -110,14 +110,16 @@ mod tests {
         let tfm = "net6.x";
         assert!(matches!(
             tfm.parse::<TargetFrameworkMoniker>(),
-            Err(ParseTargetFrameworkError::InvalidFormat(_))
+            Err(ParseTargetFrameworkError::InvalidFormat(s)) if s == *tfm
+        ));
+    }
 
     #[test]
     fn test_parse_invalid_no_version() {
         let tfm = "net";
         assert!(matches!(
             tfm.parse::<TargetFrameworkMoniker>(),
-            Err(ParseTargetFrameworkError::InvalidFormat(s))
+            Err(ParseTargetFrameworkError::InvalidFormat(s)) if s == *tfm
         ));
     }
 
@@ -126,7 +128,7 @@ mod tests {
         let tfm = "net6.0-ios15.0";
         assert!(matches!(
             tfm.parse::<TargetFrameworkMoniker>(),
-            Err(ParseTargetFrameworkError::UnsupportedOSTfm(_))
+            Err(ParseTargetFrameworkError::UnsupportedOSTfm(s)) if s == *tfm
         ));
     }
 }

--- a/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
+++ b/buildpacks/dotnet/src/dotnet/target_framework_moniker.rs
@@ -17,7 +17,7 @@ impl FromStr for TargetFrameworkMoniker {
     type Err = ParseTargetFrameworkError;
 
     fn from_str(tfm: &str) -> Result<Self, Self::Err> {
-        let supported_prefixes = ["net"];
+        let supported_prefix = "net";
 
         if tfm.len() < 3 {
             return Err(ParseTargetFrameworkError::InvalidFormat(tfm.to_string()));
@@ -26,7 +26,7 @@ impl FromStr for TargetFrameworkMoniker {
         let prefix = &tfm[..3];
         let rest = &tfm[3..];
 
-        if !supported_prefixes.contains(&prefix) {
+        if !supported_prefix.contains(prefix) {
             return Err(ParseTargetFrameworkError::InvalidFormat(tfm.to_string()));
         }
 

--- a/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
+++ b/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
@@ -179,4 +179,19 @@ mod tests {
         }
         assert!(detect_msbuild_verbosity_level(&Env::new()).is_none());
     }
+
+    #[test]
+    fn test_verbosity_level_display() {
+        let cases = [
+            (VerbosityLevel::Quiet, "quiet"),
+            (VerbosityLevel::Minimal, "minimal"),
+            (VerbosityLevel::Normal, "normal"),
+            (VerbosityLevel::Detailed, "detailed"),
+            (VerbosityLevel::Diagnostic, "diagnostic"),
+        ];
+
+        for (level, expected) in cases {
+            assert_eq!(level.to_string(), expected);
+        }
+    }
 }

--- a/buildpacks/dotnet/src/dotnet_sdk_command.rs
+++ b/buildpacks/dotnet/src/dotnet_sdk_command.rs
@@ -73,141 +73,122 @@ mod tests {
 
     #[test]
     fn test_process_from_dotnet_test_command() {
-        let test_command = DotnetTestCommand {
-            path: PathBuf::from("/foo/bar.sln"),
-            configuration: None,
-            verbosity_level: None,
-        };
-        let expected_process = Process {
-            r#type: process_type!("test"),
-            command: vec![
-                "dotnet".to_string(),
-                "test".to_string(),
-                "bar.sln".to_string(),
-            ],
-            args: vec![],
-            default: false,
-            working_directory: WorkingDirectory::App,
-        };
-
-        assert_eq!(Process::from(test_command), expected_process);
+        let test_command = base_test_command();
+        let process = Process::from(test_command);
+        assert_test_process(&process, &base_test_command_args());
     }
 
     #[test]
     fn test_process_from_dotnet_test_command_with_spaces_in_path() {
-        let test_command = DotnetTestCommand {
-            path: PathBuf::from("/foo/bar baz.sln"),
-            configuration: None,
-            verbosity_level: None,
-        };
-        let expected_process = Process {
-            r#type: process_type!("test"),
-            command: vec![
+        let mut test_command = base_test_command();
+        test_command.path = PathBuf::from("/foo/bar baz.sln");
+
+        let process = Process::from(test_command);
+        assert_test_process(
+            &process,
+            &[
                 "dotnet".to_string(),
                 "test".to_string(),
                 "bar baz.sln".to_string(),
             ],
-            args: vec![],
-            default: false,
-            working_directory: WorkingDirectory::App,
-        };
-
-        assert_eq!(Process::from(test_command), expected_process);
+        );
     }
 
     #[test]
     fn test_process_from_dotnet_test_command_with_configuration_and_verbosity_level() {
-        let test_command = DotnetTestCommand {
-            path: PathBuf::from("/foo/bar.sln"),
-            configuration: Some("Release".to_string()),
-            verbosity_level: Some(VerbosityLevel::Normal),
-        };
-        let expected_process = Process {
-            r#type: process_type!("test"),
-            command: vec![
-                "dotnet".to_string(),
-                "test".to_string(),
-                "bar.sln".to_string(),
-                "--configuration".to_string(),
-                "Release".to_string(),
-                "--verbosity".to_string(),
-                "normal".to_string(),
-            ],
-            args: vec![],
-            default: false,
-            working_directory: WorkingDirectory::App,
-        };
+        let mut test_command = base_test_command();
+        test_command.configuration = Some("Release".to_string());
+        test_command.verbosity_level = Some(VerbosityLevel::Normal);
 
-        assert_eq!(Process::from(test_command), expected_process);
+        let process = Process::from(test_command);
+        let mut expected_args = base_test_command_args();
+        expected_args.extend(vec![
+            "--configuration".to_string(),
+            "Release".to_string(),
+            "--verbosity".to_string(),
+            "normal".to_string(),
+        ]);
+        assert_test_process(&process, &expected_args);
+    }
+
+    fn assert_test_process(process: &Process, expected_command: &[String]) {
+        assert_eq!(process.r#type, process_type!("test"));
+        assert_eq!(process.command, expected_command);
+        assert_eq!(process.args, Vec::<String>::new());
+        assert!(!process.default);
+        assert_eq!(process.working_directory, WorkingDirectory::App);
+    }
+
+    fn base_test_command() -> DotnetTestCommand {
+        DotnetTestCommand {
+            path: PathBuf::from("/foo/bar.sln"),
+            configuration: None,
+            verbosity_level: None,
+        }
+    }
+
+    fn base_test_command_args() -> Vec<String> {
+        vec![
+            "dotnet".to_string(),
+            "test".to_string(),
+            "bar.sln".to_string(),
+        ]
     }
 
     #[test]
     fn test_command_from_dotnet_publish_command() {
-        let publish_command = DotnetPublishCommand {
-            path: PathBuf::from("/foo/bar.sln"),
-            runtime_identifier: RuntimeIdentifier::LinuxX64,
-            configuration: None,
-            verbosity_level: None,
-        };
-
+        let publish_command = base_publish_command();
         let command = Command::from(publish_command);
-        let args: Vec<String> = command
-            .get_args()
-            .map(|s| s.to_string_lossy().to_string())
-            .collect();
-
-        assert_eq!(command.get_program(), "dotnet");
-        assert_eq!(
-            args,
-            vec![
-                "publish".to_string(),
-                "/foo/bar.sln".to_string(),
-                "--runtime".to_string(),
-                "linux-x64".to_string(),
-                "-p:PublishDir=bin/publish".to_string(),
-                "--artifacts-path".to_string(),
-                temp_dir()
-                    .join("build_artifacts")
-                    .to_string_lossy()
-                    .to_string(),
-            ]
-        );
+        assert_publish_command_args(&command, &base_publish_command_args());
     }
 
     #[test]
     fn test_command_from_dotnet_publish_command_with_configuration_and_verbosity_level() {
-        let publish_command = DotnetPublishCommand {
-            path: PathBuf::from("/foo/bar.sln"),
-            runtime_identifier: RuntimeIdentifier::LinuxX64,
-            configuration: Some("Release".to_string()),
-            verbosity_level: Some(VerbosityLevel::Normal),
-        };
+        let mut publish_command = base_publish_command();
+        publish_command.configuration = Some("Release".to_string());
+        publish_command.verbosity_level = Some(VerbosityLevel::Normal);
 
         let command = Command::from(publish_command);
+        let mut expected_args = base_publish_command_args();
+        expected_args.extend(vec![
+            "--configuration".to_string(),
+            "Release".to_string(),
+            "--verbosity".to_string(),
+            "normal".to_string(),
+        ]);
+        assert_publish_command_args(&command, &expected_args);
+    }
+
+    fn assert_publish_command_args(command: &Command, expected_args: &[String]) {
+        assert_eq!(command.get_program(), "dotnet");
         let args: Vec<String> = command
             .get_args()
             .map(|s| s.to_string_lossy().to_string())
             .collect();
+        assert_eq!(args, expected_args);
+    }
 
-        assert_eq!(command.get_program(), "dotnet");
-        assert_eq!(
-            args,
-            vec![
-                "publish".to_string(),
-                "/foo/bar.sln".to_string(),
-                "--runtime".to_string(),
-                "linux-x64".to_string(),
-                "-p:PublishDir=bin/publish".to_string(),
-                "--artifacts-path".to_string(),
-                temp_dir()
-                    .join("build_artifacts")
-                    .to_string_lossy()
-                    .to_string(),
-                "--configuration".to_string(),
-                "Release".to_string(),
-                "--verbosity".to_string(),
-                "normal".to_string(),
-            ]
-        );
+    fn base_publish_command() -> DotnetPublishCommand {
+        DotnetPublishCommand {
+            path: PathBuf::from("/foo/bar.sln"),
+            runtime_identifier: RuntimeIdentifier::LinuxX64,
+            configuration: None,
+            verbosity_level: None,
+        }
+    }
+
+    fn base_publish_command_args() -> Vec<String> {
+        vec![
+            "publish".to_string(),
+            "/foo/bar.sln".to_string(),
+            "--runtime".to_string(),
+            "linux-x64".to_string(),
+            "-p:PublishDir=bin/publish".to_string(),
+            "--artifacts-path".to_string(),
+            temp_dir()
+                .join("build_artifacts")
+                .to_string_lossy()
+                .to_string(),
+        ]
     }
 }

--- a/buildpacks/dotnet/src/dotnet_sdk_command.rs
+++ b/buildpacks/dotnet/src/dotnet_sdk_command.rs
@@ -140,4 +140,74 @@ mod tests {
 
         assert_eq!(Process::from(test_command), expected_process);
     }
+
+    #[test]
+    fn test_command_from_dotnet_publish_command() {
+        let publish_command = DotnetPublishCommand {
+            path: PathBuf::from("/foo/bar.sln"),
+            runtime_identifier: RuntimeIdentifier::LinuxX64,
+            configuration: None,
+            verbosity_level: None,
+        };
+
+        let command = Command::from(publish_command);
+        let args: Vec<String> = command
+            .get_args()
+            .map(|s| s.to_string_lossy().to_string())
+            .collect();
+
+        assert_eq!(command.get_program(), "dotnet");
+        assert_eq!(
+            args,
+            vec![
+                "publish".to_string(),
+                "/foo/bar.sln".to_string(),
+                "--runtime".to_string(),
+                "linux-x64".to_string(),
+                "-p:PublishDir=bin/publish".to_string(),
+                "--artifacts-path".to_string(),
+                temp_dir()
+                    .join("build_artifacts")
+                    .to_string_lossy()
+                    .to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_command_from_dotnet_publish_command_with_configuration_and_verbosity_level() {
+        let publish_command = DotnetPublishCommand {
+            path: PathBuf::from("/foo/bar.sln"),
+            runtime_identifier: RuntimeIdentifier::LinuxX64,
+            configuration: Some("Release".to_string()),
+            verbosity_level: Some(VerbosityLevel::Normal),
+        };
+
+        let command = Command::from(publish_command);
+        let args: Vec<String> = command
+            .get_args()
+            .map(|s| s.to_string_lossy().to_string())
+            .collect();
+
+        assert_eq!(command.get_program(), "dotnet");
+        assert_eq!(
+            args,
+            vec![
+                "publish".to_string(),
+                "/foo/bar.sln".to_string(),
+                "--runtime".to_string(),
+                "linux-x64".to_string(),
+                "-p:PublishDir=bin/publish".to_string(),
+                "--artifacts-path".to_string(),
+                temp_dir()
+                    .join("build_artifacts")
+                    .to_string_lossy()
+                    .to_string(),
+                "--configuration".to_string(),
+                "Release".to_string(),
+                "--verbosity".to_string(),
+                "normal".to_string(),
+            ]
+        );
+    }
 }

--- a/buildpacks/dotnet/src/utils.rs
+++ b/buildpacks/dotnet/src/utils.rs
@@ -138,4 +138,46 @@ mod tests {
         assert!(to_rfc1123_label("!!!").is_err());
         assert!(to_rfc1123_label("###@@@%%%").is_err());
     }
+
+    #[test]
+    fn test_copy_recursively_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let src_file = temp_dir.path().join("test.txt");
+        let dst_file = temp_dir.path().join("copy.txt");
+
+        fs::write(&src_file, "test content").unwrap();
+
+        copy_recursively(&src_file, &dst_file).unwrap();
+
+        assert!(dst_file.exists());
+        assert_eq!(fs::read_to_string(&dst_file).unwrap(), "test content");
+    }
+
+    #[test]
+    fn test_copy_recursively_directory() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let src_dir = temp_dir.path().join("src");
+        let dst_dir = temp_dir.path().join("dst");
+
+        fs::create_dir_all(&src_dir).unwrap();
+        fs::write(src_dir.join("file1.txt"), "file1 content").unwrap();
+        fs::create_dir_all(src_dir.join("subdir")).unwrap();
+        fs::write(src_dir.join("subdir").join("file2.txt"), "file2 content").unwrap();
+
+        copy_recursively(&src_dir, &dst_dir).unwrap();
+
+        assert!(dst_dir.exists());
+        assert!(dst_dir.join("file1.txt").exists());
+        assert!(dst_dir.join("subdir").exists());
+        assert!(dst_dir.join("subdir").join("file2.txt").exists());
+    }
+
+    #[test]
+    fn test_copy_recursively_nonexistent_source() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let src = temp_dir.path().join("nonexistent");
+        let dst = temp_dir.path().join("copy");
+
+        assert!(copy_recursively(&src, &dst).is_err());
+    }
 }


### PR DESCRIPTION
This PR adds and refactors tests to increase test coverage without introducing functional changes (except from [this change to the project file parsing logic](https://github.com/heroku/buildpacks-dotnet/pull/256/commits/226c2df3862e438e6fe0c8d0bffac16174b5d764)).

Found by using `cargo-llvm-cov` and `cargo-mutants`:
https://github.com/taiki-e/cargo-llvm-cov
https://github.com/sourcefrog/cargo-mutants

Note that no tests were added to the `main.rs` or `layers/*.rs` files. While there's room for improvement in those files as well, increasing test coverage would mostly involve refactoring logic to files changed in this PR. I'll introduce those changes separately to avoid increasing the burden for reviewers of this PR.

GUS-W-18275411