### PR TITLE
Use fs-err

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,7 @@ name = "buildpack-heroku-dotnet"
 version = "0.0.0"
 dependencies = [
  "bullet_stream",
+ "fs-err",
  "fun_run",
  "hex",
  "indoc",
@@ -463,6 +464,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f89bda4c2a21204059a977ed3bfe746677dfd137b83c339e702b0ac91d482aa"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/buildpacks/dotnet/Cargo.toml
+++ b/buildpacks/dotnet/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 bullet_stream = "0.7"
+fs-err = "3.1.0"
 fun_run = "0.5"
 hex = "0.4"
 indoc = "2"

--- a/buildpacks/dotnet/src/detect.rs
+++ b/buildpacks/dotnet/src/detect.rs
@@ -1,4 +1,3 @@
-use std::fs::{self};
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -14,7 +13,7 @@ pub(crate) fn get_files_with_extensions(
     dir: &Path,
     extensions: &[&str],
 ) -> Result<Vec<PathBuf>, io::Error> {
-    let project_files = fs::read_dir(dir)?
+    let project_files = fs_err::read_dir(dir)?
         .filter_map(Result::ok)
         .map(|entry| entry.path())
         .filter(|path| path.is_file())
@@ -42,7 +41,7 @@ pub(crate) fn dotnet_tools_manifest_file<P: AsRef<Path>>(dir: P) -> Option<PathB
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::{File, create_dir};
+    use std::fs::{self, File, create_dir};
     use tempfile::TempDir;
 
     #[test]

--- a/buildpacks/dotnet/src/dotnet/project.rs
+++ b/buildpacks/dotnet/src/dotnet/project.rs
@@ -1,6 +1,6 @@
 use roxmltree::Document;
+use std::io;
 use std::path::{Path, PathBuf};
-use std::{fs, io};
 
 #[derive(Debug)]
 pub(crate) struct Project {
@@ -13,7 +13,7 @@ pub(crate) struct Project {
 
 impl Project {
     pub(crate) fn load_from_path(path: &Path) -> Result<Self, LoadError> {
-        let content = fs::read_to_string(path).map_err(LoadError::ReadProjectFile)?;
+        let content = fs_err::read_to_string(path).map_err(LoadError::ReadProjectFile)?;
         let metadata =
             parse_metadata(&Document::parse(&content).map_err(LoadError::XmlParseError)?);
 
@@ -124,6 +124,7 @@ fn infer_project_type(metadata: &Metadata) -> ProjectType {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     fn assert_metadata(
         project_xml: &str,

--- a/buildpacks/dotnet/src/dotnet/solution.rs
+++ b/buildpacks/dotnet/src/dotnet/solution.rs
@@ -1,6 +1,5 @@
 use crate::dotnet::project::{self, Project};
 use regex::Regex;
-use std::fs::{self};
 use std::io::{self};
 use std::path::{Path, PathBuf};
 
@@ -14,7 +13,7 @@ impl Solution {
         Ok(Self {
             path: path.to_path_buf(),
             projects: extract_project_references(
-                &fs::read_to_string(path).map_err(LoadError::ReadSolutionFile)?,
+                &fs_err::read_to_string(path).map_err(LoadError::ReadSolutionFile)?,
             )
             .into_iter()
             .filter_map(|project_path| {

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -39,7 +39,7 @@ use sha2::Sha512;
 use std::io::{Write, stderr};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::{env, fs, io};
+use std::{env, io};
 
 struct DotnetBuildpack;
 
@@ -381,7 +381,7 @@ fn detect_global_json_sdk_configuration(
     detect::global_json_file(app_dir).map_or_else(
         || Ok(None),
         |file| {
-            fs::read_to_string(file)
+            fs_err::read_to_string(file)
                 .map_err(DotnetBuildpackError::ReadGlobalJsonFile)
                 .and_then(|content| {
                     content

--- a/buildpacks/dotnet/src/utils.rs
+++ b/buildpacks/dotnet/src/utils.rs
@@ -1,10 +1,9 @@
-use std::fs;
 use std::path::Path;
 
 pub(crate) fn copy_recursively<P: AsRef<Path>>(src: P, dst: P) -> std::io::Result<()> {
     if src.as_ref().is_dir() {
-        fs::create_dir_all(dst.as_ref())?;
-        for entry in fs::read_dir(src)? {
+        fs_err::create_dir_all(dst.as_ref())?;
+        for entry in fs_err::read_dir(src.as_ref())? {
             let entry = entry?;
             let src_path = entry.path();
             let dst_path = dst.as_ref().join(entry.file_name());
@@ -12,7 +11,7 @@ pub(crate) fn copy_recursively<P: AsRef<Path>>(src: P, dst: P) -> std::io::Resul
             copy_recursively(&src_path, &dst_path)?;
         }
     } else {
-        fs::copy(src, dst)?;
+        fs_err::copy(src, dst)?;
     }
     Ok(())
 }
@@ -80,6 +79,7 @@ pub(crate) fn to_rfc1123_label(input: &str) -> Result<String, ()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     #[test]
     fn test_allows_letters_digits_hyphen() {


### PR DESCRIPTION
This PR simply replaces `std::fs` with `fs_err` in non-test code to provide more helpful error messages in some cases. For instance, the debug info when a project file referenced in a solution doesn't exist currently returns a generic IO error:

```
- Debug info
  - No such file or directory (os error 2)

! Error loading the project file
!
! An unexpected I/O error occurred while reading solution project files.
!
! Use the debug information above to troubleshoot and retry your build. If the
! issue persists, file an issue here:
! https://github.com/heroku/buildpacks-dotnet/issues/new
```

With this change, the debug info now includes the path to the project file:

```
- Debug info
  - failed to open file `/workspace/Frontend/Frontend.cspro`: No such file or directory (os error 2)
...
```

This type of error could arguably be handled better with a specific `project::LoadError` variant, for instance taking the project file path as the argument after checking that it doesn't exist, and writing an error message for that scenario specifically (rather than the generic `LoadError::ReadProjectFile(std::io::Error)`).

While we may want to add that in the future, using `fs_err` improves the error output for generic IO errors with minimal changes.