### PR TITLE
Handle missing solution project file

### DIFF
--- a/buildpacks/dotnet/CHANGELOG.md
+++ b/buildpacks/dotnet/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Enhance error message for missing project references in solution files to include common causes and detailed resolution steps. ([#259](https://github.com/heroku/buildpacks-dotnet/pull/259))
+
 ## [0.5.0] - 2025-04-14
 
 ### Changed

--- a/buildpacks/dotnet/src/dotnet/solution.rs
+++ b/buildpacks/dotnet/src/dotnet/solution.rs
@@ -16,9 +16,7 @@ impl Solution {
                 &fs_err::read_to_string(path).map_err(LoadError::ReadSolutionFile)?,
             )
             .into_iter()
-            .filter_map(|relative_project_path| {
-                path.parent().map(|dir| dir.join(&relative_project_path))
-            })
+            .filter_map(|project_path| path.parent().map(|dir| dir.join(&project_path)))
             .map(try_load_project)
             .collect::<Result<Vec<_>, _>>()?,
         })
@@ -32,15 +30,14 @@ impl Solution {
     }
 }
 
-fn try_load_project(project_path: PathBuf) -> Result<Project, LoadError> {
-    project_path
-        .try_exists()
+fn try_load_project(path: PathBuf) -> Result<Project, LoadError> {
+    path.try_exists()
         .map_err(|error| LoadError::LoadProject(project::LoadError::ReadProjectFile(error)))
         .and_then(|exists| {
             if exists {
-                Project::load_from_path(&project_path).map_err(LoadError::LoadProject)
+                Project::load_from_path(&path).map_err(LoadError::LoadProject)
             } else {
-                Err(LoadError::ProjectNotFound(project_path))
+                Err(LoadError::ProjectNotFound(path))
             }
         })
 }

--- a/buildpacks/dotnet/src/dotnet/solution.rs
+++ b/buildpacks/dotnet/src/dotnet/solution.rs
@@ -19,10 +19,13 @@ impl Solution {
             .filter_map(|project_path| {
                 path.parent().map(|dir| {
                     let full_project_path = dir.join(&project_path);
-                    if full_project_path.exists() {
-                        Project::load_from_path(&full_project_path).map_err(LoadError::LoadProject)
-                    } else {
-                        Err(LoadError::ProjectNotFound(full_project_path))
+                    match full_project_path.try_exists() {
+                        Ok(true) => Project::load_from_path(&full_project_path)
+                            .map_err(LoadError::LoadProject),
+                        Ok(false) => Err(LoadError::ProjectNotFound(full_project_path)),
+                        Err(error) => Err(LoadError::LoadProject(
+                            project::LoadError::ReadProjectFile(error),
+                        )),
                     }
                 })
             })

--- a/buildpacks/dotnet/src/dotnet/solution.rs
+++ b/buildpacks/dotnet/src/dotnet/solution.rs
@@ -105,6 +105,20 @@ mod tests {
     }
 
     #[test]
+    fn test_try_load_project_with_invalid_path() {
+        // Create an invalid path with null bytes which will cause try_exists() to fail
+        let invalid_path = PathBuf::from("some\0file.csproj");
+
+        let result = try_load_project(invalid_path);
+        assert!(matches!(
+            result,
+            Err(LoadError::LoadProject(project::LoadError::ReadProjectFile(
+                _
+            )))
+        ));
+    }
+
+    #[test]
     fn test_extract_project_references_should_find_all_projects_in_solution() {
         let project_references = extract_project_references(SOLUTION_WITH_TWO_PROJECTS);
 

--- a/buildpacks/dotnet/src/errors.rs
+++ b/buildpacks/dotnet/src/errors.rs
@@ -96,6 +96,20 @@ fn on_buildpack_error_with_writer(error: &DotnetBuildpackError, mut writer: impl
                     "reading solution project files",
                 );
             }
+            solution::LoadError::ProjectNotFound(project_path) => {
+                log_error_to(
+                    &mut writer,
+                    "Solution project not found",
+                    formatdoc! {"
+                    The solution references a project file that does not exist: `{}`.
+    
+                    To resolve this issue,
+                    * Ensure the project file exists.
+                    * Or remove the project reference from the solution file.
+                    ", project_path.to_string_lossy()},
+                    None,
+                );
+            }
         },
         DotnetBuildpackError::LoadProjectFile(error) => {
             on_load_dotnet_project_error_with_writer(
@@ -462,6 +476,15 @@ mod tests {
     fn test_load_solution_file_read_error() {
         assert_error_snapshot(DotnetBuildpackError::LoadSolutionFile(
             solution::LoadError::ReadSolutionFile(create_io_error()),
+        ));
+    }
+
+    #[test]
+    fn test_load_solution_file_project_not_found_error() {
+        assert_error_snapshot(DotnetBuildpackError::LoadSolutionFile(
+            solution::LoadError::ProjectNotFound(std::path::PathBuf::from(
+                "src/MyProject/MyProject.csproj",
+            )),
         ));
     }
 

--- a/buildpacks/dotnet/src/errors.rs
+++ b/buildpacks/dotnet/src/errors.rs
@@ -99,13 +99,20 @@ fn on_buildpack_error_with_writer(error: &DotnetBuildpackError, mut writer: impl
             solution::LoadError::ProjectNotFound(project_path) => {
                 log_error_to(
                     &mut writer,
-                    "Solution project not found",
+                    "Missing project referenced in solution",
                     formatdoc! {"
                     The solution references a project file that does not exist: `{}`.
-    
-                    To resolve this issue,
-                    * Ensure the project file exists.
-                    * Or remove the project reference from the solution file.
+
+                    This error occurs when a project referenced in the solution file cannot be found at
+                    the expected location. This can happen if:
+                    * The project was moved or renamed.
+                    * The project was deleted but not removed from the solution.
+                    * The project path in the solution file is incorrect.
+
+                    To resolve this issue:
+                    * Verify the project exists at the expected location.
+                    * Update the project reference path in the solution file.
+                    * Or remove the project reference from the solution if it's no longer needed.
                     ", project_path.to_string_lossy()},
                     None,
                 );

--- a/buildpacks/dotnet/src/snapshots/load_solution_file_project_not_found_error.snap
+++ b/buildpacks/dotnet/src/snapshots/load_solution_file_project_not_found_error.snap
@@ -1,0 +1,10 @@
+---
+source: buildpacks/dotnet/src/errors.rs
+---
+[0;31m! Solution project not found[0m
+[0;31m![0m
+[0;31m! The solution references a project file that does not exist: `src/MyProject/MyProject.csproj`.[0m
+[0;31m![0m
+[0;31m! To resolve this issue,[0m
+[0;31m! * Ensure the project file exists.[0m
+[0;31m! * Or remove the project reference from the solution file.[0m

--- a/buildpacks/dotnet/src/snapshots/load_solution_file_project_not_found_error.snap
+++ b/buildpacks/dotnet/src/snapshots/load_solution_file_project_not_found_error.snap
@@ -1,10 +1,17 @@
 ---
 source: buildpacks/dotnet/src/errors.rs
 ---
-[0;31m! Solution project not found[0m
+[0;31m! Missing project referenced in solution[0m
 [0;31m![0m
 [0;31m! The solution references a project file that does not exist: `src/MyProject/MyProject.csproj`.[0m
 [0;31m![0m
-[0;31m! To resolve this issue,[0m
-[0;31m! * Ensure the project file exists.[0m
-[0;31m! * Or remove the project reference from the solution file.[0m
+[0;31m! This error occurs when a project referenced in the solution file cannot be found at[0m
+[0;31m! the expected location. This can happen if:[0m
+[0;31m! * The project was moved or renamed.[0m
+[0;31m! * The project was deleted but not removed from the solution.[0m
+[0;31m! * The project path in the solution file is incorrect.[0m
+[0;31m![0m
+[0;31m! To resolve this issue:[0m
+[0;31m! * Verify the project exists at the expected location.[0m
+[0;31m! * Update the project reference path in the solution file.[0m
+[0;31m! * Or remove the project reference from the solution if it's no longer needed.[0m


### PR DESCRIPTION
This PR improves error handling when a solution file references a project file that does not exist.

Also see https://github.com/heroku/buildpacks-dotnet/pull/258