### PR TITLE
Refactor SDK layer handling logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,7 @@ dependencies = [
  "libcnb-test",
  "libherokubuildpack",
  "regex",
+ "retry",
  "roxmltree",
  "semver",
  "serde",
@@ -1406,6 +1407,12 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "retry"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e211f878258887b3e65dd3c8ff9f530fe109f441a117ee0cdc27f341355032"
 
 [[package]]
 name = "ring"

--- a/buildpacks/dotnet/Cargo.toml
+++ b/buildpacks/dotnet/Cargo.toml
@@ -17,6 +17,7 @@ indoc = "2"
 libcnb = { version = "0.29", features = ["trace"] }
 libherokubuildpack = { version = "0.29", default-features = false, features = ["tar", "download", "inventory", "inventory-semver", "inventory-sha2"] }
 regex = "1"
+retry = { version = "2.1.0", default-features = false }
 roxmltree = "0.20"
 semver = "1.0"
 serde = "1"

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -31,6 +31,7 @@ pub(crate) enum CustomCause {
 }
 
 const MAX_RETRIES: u8 = 4;
+const RETRY_DELAY: Duration = Duration::from_secs(1);
 
 pub(crate) fn handle(
     context: &libcnb::build::BuildContext<DotnetBuildpack>,
@@ -115,7 +116,7 @@ fn download_sdk(
         match download_result {
             Ok(()) => break,
             Err(DownloadError::IoError(_)) if attempt_index < MAX_RETRIES => {
-                thread::sleep(Duration::from_secs(1));
+                thread::sleep(RETRY_DELAY);
             }
             Err(error) => {
                 Err(SdkLayerError::DownloadArchive(error))?;

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -109,13 +109,18 @@ fn download_sdk(
 
         let download_result = download_file(&artifact.url, path);
         match download_result {
-            Err(DownloadError::IoError(error)) if attempt_index < MAX_RETRIES => {
-                log_progress.cancel(format!("Failed: {error}"));
+            Err(DownloadError::IoError(ref error)) => {
+                log_progress.cancel(format!("Failed: {error}"))
+            }
+            Err(DownloadError::HttpError(_)) => unimplemented!(), // TODO: Added this match arm for refactoring (to show the previous lack of log_progress state handling for this failure mode).
+            Ok(()) => log_progress.done(),
+        };
+        match download_result {
+            Err(DownloadError::IoError(_)) if attempt_index < MAX_RETRIES => {
                 thread::sleep(Duration::from_secs(1));
             }
             result => {
                 result.map_err(SdkLayerError::DownloadArchive)?;
-                log_progress.done();
                 break;
             }
         }

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -113,13 +113,13 @@ fn download_sdk(
             Err(ref error) => log_progress.cancel(format!("Failed: {error}")),
         };
         match download_result {
+            Ok(()) => break,
             Err(DownloadError::IoError(_)) if attempt_index < MAX_RETRIES => {
                 thread::sleep(Duration::from_secs(1));
             }
             Err(error) => {
                 Err(SdkLayerError::DownloadArchive(error))?;
             }
-            Ok(()) => break,
         }
     }
     Ok(())

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -109,8 +109,8 @@ fn download_sdk(
 
         let download_result = download_file(&artifact.url, path);
         match download_result {
-            Err(ref error) => log_progress.cancel(format!("Failed: {error}")),
             Ok(()) => log_progress.done(),
+            Err(ref error) => log_progress.cancel(format!("Failed: {error}")),
         };
         match download_result {
             Err(DownloadError::IoError(_)) if attempt_index < MAX_RETRIES => {

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -95,7 +95,7 @@ fn download_sdk(
     artifact: &Artifact<Version, Sha512, Option<()>>,
     path: &Path,
 ) -> Result<(), SdkLayerError> {
-    let mut log_background_bullet = print::sub_start_timer(format!(
+    let mut log_progress = print::sub_start_timer(format!(
         "Downloading SDK from {}",
         style::url(artifact.clone().url)
     ));
@@ -103,14 +103,14 @@ fn download_sdk(
     while download_attempts <= MAX_RETRIES {
         match download_file(&artifact.url, &path) {
             Err(DownloadError::IoError(error)) if download_attempts < MAX_RETRIES => {
-                let sub_bullet = log_background_bullet.cancel(format!("{error}"));
+                let sub_bullet = log_progress.cancel(format!("{error}"));
                 download_attempts += 1;
                 thread::sleep(Duration::from_secs(1));
-                log_background_bullet = sub_bullet.start_timer("Retrying");
+                log_progress = sub_bullet.start_timer("Retrying");
             }
             result => {
                 result.map_err(SdkLayerError::DownloadArchive)?;
-                log_background_bullet.done();
+                log_progress.done();
                 break;
             }
         }

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -77,12 +77,12 @@ pub(crate) fn handle(
                 artifact: artifact.clone(),
             })?;
 
+            let tarball_path = temp_dir().join("dotnetsdk.tar.gz");
+
             let mut log_background_bullet = print::sub_start_timer(format!(
                 "Downloading SDK from {}",
                 style::url(artifact.clone().url)
             ));
-
-            let tarball_path = temp_dir().join("dotnetsdk.tar.gz");
             let mut download_attempts = 0;
             while download_attempts <= MAX_RETRIES {
                 match download_file(&artifact.url, &tarball_path) {

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -99,12 +99,10 @@ fn download_sdk(
         "Downloading SDK from {}",
         style::url(artifact.clone().url)
     ));
-    let mut attempt = 0;
-    while attempt <= MAX_RETRIES {
+    for attempt in 0..=MAX_RETRIES {
         match download_file(&artifact.url, path) {
             Err(DownloadError::IoError(error)) if attempt < MAX_RETRIES => {
                 let sub_bullet = log_progress.cancel(format!("Failed: {error}"));
-                attempt += 1;
                 thread::sleep(Duration::from_secs(1));
                 log_progress = sub_bullet.start_timer("Retrying download");
             }

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -103,14 +103,7 @@ pub(crate) fn handle(
             print::sub_bullet("Verifying SDK checksum");
             verify_checksum(&artifact.checksum, &tarball_path)?;
 
-            print::sub_bullet("Installing SDK");
-            decompress_tarball(
-                &mut File::open(&tarball_path)
-                    .map_err(SdkLayerError::OpenArchive)?
-                    .into(),
-                sdk_layer.path(),
-            )
-            .map_err(SdkLayerError::DecompressArchive)?;
+            extract_archive(&tarball_path, &sdk_layer.path())?;
         }
     }
 
@@ -133,6 +126,18 @@ where
             actual: calculated_checksum,
         })
     }
+}
+
+fn extract_archive(source_path: &Path, destination_path: &Path) -> Result<(), SdkLayerError> {
+    print::sub_bullet("Installing SDK");
+
+    decompress_tarball(
+        &mut File::open(source_path)
+            .map_err(SdkLayerError::OpenArchive)?
+            .into(),
+        destination_path,
+    )
+    .map_err(SdkLayerError::DecompressArchive)
 }
 
 #[derive(Debug)]

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -103,7 +103,7 @@ fn download_sdk(
     while attempt <= MAX_RETRIES {
         match download_file(&artifact.url, path) {
             Err(DownloadError::IoError(error)) if attempt < MAX_RETRIES => {
-                let sub_bullet = log_progress.cancel(format!("{error}"));
+                let sub_bullet = log_progress.cancel(format!("Failed: {error}"));
                 attempt += 1;
                 thread::sleep(Duration::from_secs(1));
                 log_progress = sub_bullet.start_timer("Retrying download");

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -99,7 +99,7 @@ fn download_sdk(
         let message = if attempt == 0 {
             format!("Downloading SDK from {}", style::url(&artifact.url))
         } else {
-            "Retrying download".to_string()
+            format!("Retrying download ({}/{})", attempt + 1, MAX_RETRIES + 1)
         };
         let log_progress = print::sub_start_timer(message);
 

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -109,10 +109,7 @@ fn download_sdk(
 
         let download_result = download_file(&artifact.url, path);
         match download_result {
-            Err(DownloadError::IoError(ref error)) => {
-                log_progress.cancel(format!("Failed: {error}"))
-            }
-            Err(DownloadError::HttpError(_)) => unimplemented!(), // TODO: Added this match arm for refactoring (to show the previous lack of log_progress state handling for this failure mode).
+            Err(ref error) => log_progress.cancel(format!("Failed: {error}")),
             Ok(()) => log_progress.done(),
         };
         match download_result {

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -86,7 +86,7 @@ pub(crate) fn handle(
             print::sub_bullet("Verifying SDK checksum");
             verify_checksum(&artifact.checksum, &tarball_path)?;
 
-            extract_archive(&tarball_path, &sdk_layer.path())?;
+            extract_tarball(&tarball_path, &sdk_layer.path())?;
         }
     }
 
@@ -140,14 +140,12 @@ where
     }
 }
 
-fn extract_archive(source_path: &Path, destination_path: &Path) -> Result<(), SdkLayerError> {
+fn extract_tarball(path: &Path, destination: &Path) -> Result<(), SdkLayerError> {
     print::sub_bullet("Installing SDK");
 
     decompress_tarball(
-        &mut File::open(source_path)
-            .map_err(SdkLayerError::OpenArchive)?
-            .into(),
-        destination_path,
+        &mut File::open(path).map_err(SdkLayerError::OpenArchive)?.into(),
+        destination,
     )
     .map_err(SdkLayerError::DecompressArchive)
 }

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -107,7 +107,8 @@ fn download_sdk(
         };
         let log_progress = print::sub_start_timer(message);
 
-        match download_file(&artifact.url, path) {
+        let download_result = download_file(&artifact.url, path);
+        match download_result {
             Err(DownloadError::IoError(error)) if attempt_index < MAX_RETRIES => {
                 log_progress.cancel(format!("Failed: {error}"));
                 thread::sleep(Duration::from_secs(1));

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -101,7 +101,7 @@ fn download_sdk(
     ));
     let mut attempt = 0;
     while attempt <= MAX_RETRIES {
-        match download_file(&artifact.url, &path) {
+        match download_file(&artifact.url, path) {
             Err(DownloadError::IoError(error)) if attempt < MAX_RETRIES => {
                 let sub_bullet = log_progress.cancel(format!("{error}"));
                 attempt += 1;

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -30,7 +30,7 @@ pub(crate) enum CustomCause {
     DifferentSdkArtifact(Artifact<Version, Sha512, Option<()>>),
 }
 
-const MAX_RETRIES: u8 = 4;
+const MAX_RETRIES: usize = 4;
 const RETRY_DELAY: Duration = Duration::from_secs(1);
 
 pub(crate) fn handle(

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -86,6 +86,7 @@ pub(crate) fn handle(
             print::sub_bullet("Verifying SDK checksum");
             verify_checksum(&artifact.checksum, &tarball_path)?;
 
+            print::sub_bullet("Installing SDK");
             extract_tarball(&tarball_path, &sdk_layer.path())?;
         }
     }
@@ -141,8 +142,6 @@ where
 }
 
 fn extract_tarball(path: &Path, destination: &Path) -> Result<(), SdkLayerError> {
-    print::sub_bullet("Installing SDK");
-
     decompress_tarball(
         &mut File::open(path).map_err(SdkLayerError::OpenArchive)?.into(),
         destination,

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -106,7 +106,7 @@ fn download_sdk(
                 let sub_bullet = log_progress.cancel(format!("{error}"));
                 attempt += 1;
                 thread::sleep(Duration::from_secs(1));
-                log_progress = sub_bullet.start_timer("Retrying");
+                log_progress = sub_bullet.start_timer("Retrying download");
             }
             result => {
                 result.map_err(SdkLayerError::DownloadArchive)?;

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -116,10 +116,10 @@ fn download_sdk(
             Err(DownloadError::IoError(_)) if attempt_index < MAX_RETRIES => {
                 thread::sleep(Duration::from_secs(1));
             }
-            result => {
-                result.map_err(SdkLayerError::DownloadArchive)?;
-                break;
+            Err(error) => {
+                Err(SdkLayerError::DownloadArchive(error))?;
             }
+            Ok(()) => break,
         }
     }
     Ok(())

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -126,8 +126,9 @@ where
     D: Digest,
 {
     let calculated_checksum = fs_err::read(path.as_ref())
-        .map(|data| D::digest(data).to_vec())
-        .map_err(SdkLayerError::ReadArchive)?;
+        .map_err(SdkLayerError::ReadArchive)
+        .map(D::digest)?
+        .to_vec();
 
     if calculated_checksum == checksum.value {
         Ok(())

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -95,16 +95,20 @@ fn download_sdk(
     artifact: &Artifact<Version, Sha512, Option<()>>,
     path: &Path,
 ) -> Result<(), SdkLayerError> {
-    for attempt in 0..=MAX_RETRIES {
-        let message = if attempt == 0 {
+    for attempt_index in 0..=MAX_RETRIES {
+        let message = if attempt_index == 0 {
             format!("Downloading SDK from {}", style::url(&artifact.url))
         } else {
-            format!("Retrying download ({}/{})", attempt + 1, MAX_RETRIES + 1)
+            format!(
+                "Retrying download ({}/{})",
+                attempt_index + 1,
+                MAX_RETRIES + 1
+            )
         };
         let log_progress = print::sub_start_timer(message);
 
         match download_file(&artifact.url, path) {
-            Err(DownloadError::IoError(error)) if attempt < MAX_RETRIES => {
+            Err(DownloadError::IoError(error)) if attempt_index < MAX_RETRIES => {
                 log_progress.cancel(format!("Failed: {error}"));
                 thread::sleep(Duration::from_secs(1));
             }

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -99,12 +99,12 @@ fn download_sdk(
         "Downloading SDK from {}",
         style::url(artifact.clone().url)
     ));
-    let mut download_attempts = 0;
-    while download_attempts <= MAX_RETRIES {
+    let mut attempt = 0;
+    while attempt <= MAX_RETRIES {
         match download_file(&artifact.url, &path) {
-            Err(DownloadError::IoError(error)) if download_attempts < MAX_RETRIES => {
+            Err(DownloadError::IoError(error)) if attempt < MAX_RETRIES => {
                 let sub_bullet = log_progress.cancel(format!("{error}"));
-                download_attempts += 1;
+                attempt += 1;
                 thread::sleep(Duration::from_secs(1));
                 log_progress = sub_bullet.start_timer("Retrying");
             }


### PR DESCRIPTION
This PR seeks to simplify the somewhat monolithic SDK layer handling, by extracting relevant logic into dedicated helper functions and replacing the manual download retry loop using the [retry](https://crates.io/crates/retry) crate:

- **Replaced manual retry loop:** The verbose while loop/control flow for retrying downloads on I/O errors is now handled by the `retry` crate, making the logic more declarative and robust in the process. While this implementation is (mostly) functionally equivalent, a couple of changes were introduced:
  - The log output now prints retry attempt information when a failed download is retried
  (i.e. `- Retrying download (2/5) ...... (Failed: {error}`
  - The log progress timer/state is now properly cancelled on errors (see https://github.com/heroku/buildpacks-dotnet/pull/276/commits/51fbd348f728652e5302e12ca9c04cc274657ca1 and the following commits for more details).
- **Extracted helper functions:** The SDK download and extraction steps were moved from `handle` into new `download_sdk` and `extract_tarball` functions.

These changes should help improve readability and maintainability of the code, while preparing it for upcoming work to instrument relevant operations.

GUS-W-18870000