### PR TITLE
Include .NET 10.0 releases when updating inventory

### DIFF
--- a/shared/inventory-updater/src/main.rs
+++ b/shared/inventory-updater/src/main.rs
@@ -123,7 +123,7 @@ struct File {
     hash: String,
 }
 
-const SUPPORTED_MAJOR_VERSIONS: &[i32] = &[8, 9];
+const SUPPORTED_MAJOR_VERSIONS: &[i32] = &[8, 9, 10];
 const REQUIRED_ARCHS: [Arch; 2] = [Arch::Amd64, Arch::Arm64];
 
 fn list_upstream_artifacts() -> Vec<Artifact<Version, Sha512, Option<()>>> {


### PR DESCRIPTION
This PR changes `inventory-updater` to also discover .NET 10.0 releases (in addition to .NET 8.0 and 9.0) when updating the SDK inventory.

The .NET 10 SDK preview releases that are already available will be added automatically by the GitHub action (after this PR is merged).

GUS-W-19010819