### PR TITLE
Assert `pack` integration test output from stdout

### DIFF
--- a/buildpacks/dotnet/tests/dotnet_publish_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_publish_test.rs
@@ -38,7 +38,7 @@ fn test_dotnet_publish_with_compilation_error() {
             .expected_pack_result(PackResult::Failure),
         |context| {
             assert_contains!(
-                &context.pack_stderr,
+                &context.pack_stdout,
                 &indoc! {r"
                   ! Unable to publish
                   !

--- a/buildpacks/dotnet/tests/dotnet_restore_tools_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_restore_tools_test.rs
@@ -43,7 +43,7 @@ fn test_dotnet_restore_dotnet_tool_with_configuration_error() {
                           Version 0.0.0-foobar of package dotnetsay is not found in NuGet feeds https://api.nuget.org/v3/index.json."}
             );
             assert_contains!(
-                &context.pack_stderr,
+                &context.pack_stdout,
                 &indoc! {r"
                     ! Unable to restore .NET tools
                     !


### PR DESCRIPTION
The `lifecycle` version in Heroku's CNB builder images was recently updated to `v0.20.13`, which included a fix for interleaved buildpack stdout/stderr. All `pack` output is now sent to `stdout`.

This PR updates integration tests that previously asserted error output written to `stderr`.

Also see: https://github.com/heroku/cnb-builder-images/pull/784#issuecomment-3188677609

GUS-W-19337112