### PR TITLE
Support .NET 10.0 apps without global.json config

### DIFF
--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -232,8 +232,23 @@ impl Buildpack for DotnetBuildpack {
 ))]
 fn resolve_sdk_artifact(
     target: &Target,
-    sdk_version_requirement: VersionReq,
+    mut sdk_version_requirement: VersionReq,
 ) -> Result<Artifact<Version, Sha512, Option<()>>, DotnetBuildpackError> {
+    // When VersionReq is derived from the TFM for .NET 10.0, which has no
+    // stable releases, rewrite the requirement to match preview and release
+    // candidate releases.
+    // TODO: Remove this logic when stable .NET 10.0 releases are added to the
+    // the inventory, and update the .NET 10 SDK resolution integration test.
+    if sdk_version_requirement
+        == VersionReq::try_from(&TargetFrameworkMoniker {
+            version_part: String::from("10.0"),
+        })
+        .expect("TargetFrameworkMoniker should always be parseable")
+    {
+        sdk_version_requirement = VersionReq::parse("^10.0.100-preview")
+            .expect("VersionReq string should always be parseable");
+    }
+
     include_str!("../inventory.toml")
         .parse::<Inventory<_, _, _>>()
         .map_err(DotnetBuildpackError::ParseInventory)

--- a/buildpacks/dotnet/tests/fixtures/basic_web_10.0/Program.cs
+++ b/buildpacks/dotnet/tests/fixtures/basic_web_10.0/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello World!");
+
+app.Run();

--- a/buildpacks/dotnet/tests/fixtures/basic_web_10.0/foo.csproj
+++ b/buildpacks/dotnet/tests/fixtures/basic_web_10.0/foo.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>
+

--- a/buildpacks/dotnet/tests/sdk_installation_test.rs
+++ b/buildpacks/dotnet/tests/sdk_installation_test.rs
@@ -46,6 +46,31 @@ fn test_sdk_resolution_with_target_framework_9_0() {
 
 #[test]
 #[ignore = "integration test"]
+fn test_sdk_resolution_with_target_framework_10_0() {
+    TestRunner::default().build(
+        default_build_config("tests/fixtures/basic_web_10.0"),
+        |context| {
+            assert_empty!(context.pack_stderr);
+            // The assertion below will fail when stable .NET 10.0 releases are
+            // added to the inventory.
+            // TODO: Remove pre-release logic in main::resolve_sdk_artifact
+            // and adjust the last line in the assertion to:
+            // - Resolved .NET SDK version `10.0
+            assert_contains!(
+                context.pack_stdout,
+                &indoc! {r"
+                    - SDK version detection
+                      - Detected .NET project: `/workspace/foo.csproj`
+                      - Inferring version requirement from `/workspace/foo.csproj`
+                      - Detected version requirement: `^10.0`
+                      - Resolved .NET SDK version `10.0.100-"}
+            );
+        },
+    );
+}
+
+#[test]
+#[ignore = "integration test"]
 fn test_sdk_resolution_with_solution_file() {
     TestRunner::default().build(
         default_build_config("tests/fixtures/solution_with_web_and_console_projects"),


### PR DESCRIPTION
We currently don't consider pre-release SDKs when resolving artifacts based on the `targetFramework` value.

To build and run apps using .NET 10, apps must currently specify a pre-release SDK version in `global.json` (see https://github.com/heroku/buildpacks-dotnet/pull/300 for context).

This PR adds support for discovering .NET 10.0 pre-release artifacts "out of the box" without custom `global.json` configuration based on a project's target framework. The logic introduced will support all expected preview and rc releases. 

An integration test is added, and designed to fail when stable .NET 10 releases are added to `inventory.toml` (to prompt the removal of the special logic for .NET 10 preview artifacts).

GUS-W-19400519