### PR TITLE
Refactor buildpack configuration parsing

### DIFF
--- a/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
+++ b/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
@@ -10,8 +10,8 @@ pub(crate) struct DotnetBuildpackConfiguration {
 
 #[derive(Debug, PartialEq)]
 pub(crate) enum DotnetBuildpackConfigurationError {
-    ExecutionEnvironmentError(ExecutionEnvironmentError),
-    InvalidMsbuildVerbosityLevel(ParseVerbosityLevelError),
+    ExecutionEnvironment(ExecutionEnvironmentError),
+    VerbosityLevel(ParseVerbosityLevelError),
 }
 
 impl TryFrom<&libcnb::Env> for DotnetBuildpackConfiguration {
@@ -27,13 +27,13 @@ impl TryFrom<&libcnb::Env> for DotnetBuildpackConfiguration {
                     || Ok(ExecutionEnvironment::Production),
                     ExecutionEnvironment::from_str,
                 )
-                .map_err(DotnetBuildpackConfigurationError::ExecutionEnvironmentError)?,
+                .map_err(DotnetBuildpackConfigurationError::ExecutionEnvironment)?,
             msbuild_verbosity_level: env
                 .get("MSBUILD_VERBOSITY_LEVEL")
                 .map(|value| value.to_string_lossy())
                 .map(|value| value.parse())
                 .transpose()
-                .map_err(DotnetBuildpackConfigurationError::InvalidMsbuildVerbosityLevel)?,
+                .map_err(DotnetBuildpackConfigurationError::VerbosityLevel)?,
         })
     }
 }

--- a/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
+++ b/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
@@ -37,23 +37,6 @@ impl TryFrom<&libcnb::Env> for DotnetBuildpackConfiguration {
     }
 }
 
-impl FromStr for VerbosityLevel {
-    type Err = DotnetBuildpackConfigurationError;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value.to_lowercase().as_str() {
-            "q" | "quiet" => Ok(VerbosityLevel::Quiet),
-            "m" | "minimal" => Ok(VerbosityLevel::Minimal),
-            "n" | "normal" => Ok(VerbosityLevel::Normal),
-            "d" | "detailed" => Ok(VerbosityLevel::Detailed),
-            "diag" | "diagnostic" => Ok(VerbosityLevel::Diagnostic),
-            _ => Err(
-                DotnetBuildpackConfigurationError::InvalidMsbuildVerbosityLevel(value.to_string()),
-            ),
-        }
-    }
-}
-
 #[derive(Debug, PartialEq)]
 pub(crate) enum ExecutionEnvironment {
     Production,
@@ -86,6 +69,23 @@ pub(crate) enum VerbosityLevel {
     Normal,
     Detailed,
     Diagnostic,
+}
+
+impl FromStr for VerbosityLevel {
+    type Err = DotnetBuildpackConfigurationError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_lowercase().as_str() {
+            "q" | "quiet" => Ok(VerbosityLevel::Quiet),
+            "m" | "minimal" => Ok(VerbosityLevel::Minimal),
+            "n" | "normal" => Ok(VerbosityLevel::Normal),
+            "d" | "detailed" => Ok(VerbosityLevel::Detailed),
+            "diag" | "diagnostic" => Ok(VerbosityLevel::Diagnostic),
+            _ => Err(
+                DotnetBuildpackConfigurationError::InvalidMsbuildVerbosityLevel(value.to_string()),
+            ),
+        }
+    }
 }
 
 impl fmt::Display for VerbosityLevel {

--- a/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
+++ b/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
@@ -38,7 +38,14 @@ fn detect_msbuild_verbosity_level(
 ) -> Option<Result<VerbosityLevel, DotnetBuildpackConfigurationError>> {
     env.get("MSBUILD_VERBOSITY_LEVEL")
         .map(|value| value.to_string_lossy())
-        .map(|value| match value.to_lowercase().as_str() {
+        .map(|value| value.parse())
+}
+
+impl FromStr for VerbosityLevel {
+    type Err = DotnetBuildpackConfigurationError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_lowercase().as_str() {
             "q" | "quiet" => Ok(VerbosityLevel::Quiet),
             "m" | "minimal" => Ok(VerbosityLevel::Minimal),
             "n" | "normal" => Ok(VerbosityLevel::Normal),
@@ -47,7 +54,8 @@ fn detect_msbuild_verbosity_level(
             _ => Err(
                 DotnetBuildpackConfigurationError::InvalidMsbuildVerbosityLevel(value.to_string()),
             ),
-        })
+        }
+    }
 }
 
 #[derive(Debug, PartialEq)]

--- a/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
+++ b/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
@@ -181,9 +181,8 @@ mod tests {
         ];
 
         for (input, expected) in cases {
-            let env = create_env(&[("MSBUILD_VERBOSITY_LEVEL", input)]);
-            let result = detect_msbuild_verbosity_level(&env);
-            assert_eq!(result, Some(expected));
+            let result = input.parse();
+            assert_eq!(result, expected);
         }
         assert!(detect_msbuild_verbosity_level(&Env::new()).is_none());
     }

--- a/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
+++ b/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
@@ -129,11 +129,20 @@ mod tests {
     }
 
     #[test]
-    fn test_buildpack_configuration_test_execution_environment() {
-        let env = create_env(&[("CNB_EXEC_ENV", "test")]);
+    fn test_env_overrides_default_config() {
+        let env = create_env(&[
+            ("BUILD_CONFIGURATION", "Release"),
+            ("MSBUILD_VERBOSITY_LEVEL", "Detailed"),
+            ("CNB_EXEC_ENV", "test"),
+        ]);
         let result = DotnetBuildpackConfiguration::try_from(&env).unwrap();
 
+        assert_eq!(result.build_configuration, Some("Release".to_string()));
         assert_eq!(result.execution_environment, ExecutionEnvironment::Test);
+        assert_eq!(
+            result.msbuild_verbosity_level,
+            Some(VerbosityLevel::Detailed)
+        );
     }
 
     #[test]

--- a/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
+++ b/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
@@ -28,17 +28,13 @@ impl TryFrom<&libcnb::Env> for DotnetBuildpackConfiguration {
                     ExecutionEnvironment::from_str,
                 )
                 .map_err(DotnetBuildpackConfigurationError::ExecutionEnvironmentError)?,
-            msbuild_verbosity_level: detect_msbuild_verbosity_level(env).transpose()?,
+            msbuild_verbosity_level: env
+                .get("MSBUILD_VERBOSITY_LEVEL")
+                .map(|value| value.to_string_lossy())
+                .map(|value| value.parse())
+                .transpose()?,
         })
     }
-}
-
-fn detect_msbuild_verbosity_level(
-    env: &libcnb::Env,
-) -> Option<Result<VerbosityLevel, DotnetBuildpackConfigurationError>> {
-    env.get("MSBUILD_VERBOSITY_LEVEL")
-        .map(|value| value.to_string_lossy())
-        .map(|value| value.parse())
 }
 
 impl FromStr for VerbosityLevel {

--- a/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
+++ b/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
@@ -182,7 +182,6 @@ mod tests {
             result,
             Err(DotnetBuildpackConfigurationError::InvalidMsbuildVerbosityLevel(s)) if s == "invalid"
         ));
-        assert!(detect_msbuild_verbosity_level(&Env::new()).is_none());
     }
 
     #[test]

--- a/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
+++ b/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
@@ -160,7 +160,7 @@ mod tests {
     }
 
     #[test]
-    fn test_detect_msbuild_verbosity_level() {
+    fn test_parse_msbuild_verbosity_level() {
         let valid_cases = [
             ("q", VerbosityLevel::Quiet),
             ("quiet", VerbosityLevel::Quiet),

--- a/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
+++ b/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
@@ -43,6 +43,11 @@ pub(crate) enum ExecutionEnvironment {
     Test,
 }
 
+#[derive(Debug, PartialEq)]
+pub(crate) enum ExecutionEnvironmentError {
+    UnsupportedExecutionEnvironment(String),
+}
+
 impl FromStr for ExecutionEnvironment {
     type Err = ExecutionEnvironmentError;
 
@@ -55,11 +60,6 @@ impl FromStr for ExecutionEnvironment {
             )),
         }
     }
-}
-
-#[derive(Debug, PartialEq)]
-pub(crate) enum ExecutionEnvironmentError {
-    UnsupportedExecutionEnvironment(String),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
+++ b/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
@@ -149,19 +149,14 @@ mod tests {
 
     #[test]
     fn test_parse_execution_environment() {
-        let cases = [
-            ("production", Ok(ExecutionEnvironment::Production)),
-            ("test", Ok(ExecutionEnvironment::Test)),
-            (
-                "foo",
-                Err(ExecutionEnvironmentError::UnsupportedExecutionEnvironment(
-                    "foo".to_string(),
-                )),
-            ),
-        ];
-        for (input, expected) in cases {
-            assert_eq!(ExecutionEnvironment::from_str(input), expected);
-        }
+        assert_eq!("production".parse(), Ok(ExecutionEnvironment::Production));
+        assert_eq!("test".parse(), Ok(ExecutionEnvironment::Test));
+        assert_eq!(
+            "invalid".parse::<ExecutionEnvironment>(),
+            Err(ExecutionEnvironmentError::UnsupportedExecutionEnvironment(
+                "invalid".to_string()
+            ))
+        );
     }
 
     #[test]

--- a/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
+++ b/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
@@ -159,31 +159,29 @@ mod tests {
 
     #[test]
     fn test_detect_msbuild_verbosity_level() {
-        let cases = [
-            ("q", Ok(VerbosityLevel::Quiet)),
-            ("quiet", Ok(VerbosityLevel::Quiet)),
-            ("minimal", Ok(VerbosityLevel::Minimal)),
-            ("m", Ok(VerbosityLevel::Minimal)),
-            ("normal", Ok(VerbosityLevel::Normal)),
-            ("n", Ok(VerbosityLevel::Normal)),
-            ("detailed", Ok(VerbosityLevel::Detailed)),
-            ("d", Ok(VerbosityLevel::Detailed)),
-            ("diagnostic", Ok(VerbosityLevel::Diagnostic)),
-            ("diag", Ok(VerbosityLevel::Diagnostic)),
-            (
-                "invalid",
-                Err(
-                    DotnetBuildpackConfigurationError::InvalidMsbuildVerbosityLevel(
-                        "invalid".to_string(),
-                    ),
-                ),
-            ),
+        let valid_cases = [
+            ("q", VerbosityLevel::Quiet),
+            ("quiet", VerbosityLevel::Quiet),
+            ("minimal", VerbosityLevel::Minimal),
+            ("m", VerbosityLevel::Minimal),
+            ("normal", VerbosityLevel::Normal),
+            ("n", VerbosityLevel::Normal),
+            ("detailed", VerbosityLevel::Detailed),
+            ("d", VerbosityLevel::Detailed),
+            ("diagnostic", VerbosityLevel::Diagnostic),
+            ("diag", VerbosityLevel::Diagnostic),
         ];
 
-        for (input, expected) in cases {
+        for (input, expected) in valid_cases {
             let result = input.parse();
-            assert_eq!(result, expected);
+            assert_eq!(result, Ok(expected));
         }
+
+        let result = "invalid".parse::<VerbosityLevel>();
+        assert!(matches!(
+            result,
+            Err(DotnetBuildpackConfigurationError::InvalidMsbuildVerbosityLevel(s)) if s == "invalid"
+        ));
         assert!(detect_msbuild_verbosity_level(&Env::new()).is_none());
     }
 

--- a/buildpacks/dotnet/src/errors.rs
+++ b/buildpacks/dotnet/src/errors.rs
@@ -262,9 +262,9 @@ fn on_buildpack_error_with_writer(error: &DotnetBuildpackError, mut writer: impl
             ),
         },
         DotnetBuildpackError::ParseBuildpackConfiguration(error) => match error {
-            DotnetBuildpackConfigurationError::InvalidMsbuildVerbosityLevel(
-                ParseVerbosityLevelError(verbosity_level),
-            ) => {
+            DotnetBuildpackConfigurationError::VerbosityLevel(ParseVerbosityLevelError(
+                verbosity_level,
+            )) => {
                 log_error_to(
                     &mut writer,
                     "Invalid MSBuild verbosity level",
@@ -286,7 +286,7 @@ fn on_buildpack_error_with_writer(error: &DotnetBuildpackError, mut writer: impl
                     None,
                 );
             }
-            DotnetBuildpackConfigurationError::ExecutionEnvironmentError(error) => match error {
+            DotnetBuildpackConfigurationError::ExecutionEnvironment(error) => match error {
                 ExecutionEnvironmentError::UnsupportedExecutionEnvironment(
                     execution_environment,
                 ) => {
@@ -653,16 +653,16 @@ mod tests {
     #[test]
     fn test_parse_buildpack_configuration_invalid_msbuild_verbosity_level_error() {
         assert_error_snapshot(DotnetBuildpackError::ParseBuildpackConfiguration(
-            DotnetBuildpackConfigurationError::InvalidMsbuildVerbosityLevel(
-                ParseVerbosityLevelError("Foo".to_string()),
-            ),
+            DotnetBuildpackConfigurationError::VerbosityLevel(ParseVerbosityLevelError(
+                "Foo".to_string(),
+            )),
         ));
     }
 
     #[test]
     fn test_parse_buildpack_configuration_unsupported_execution_environment_error() {
         assert_error_snapshot(DotnetBuildpackError::ParseBuildpackConfiguration(
-            DotnetBuildpackConfigurationError::ExecutionEnvironmentError(
+            DotnetBuildpackConfigurationError::ExecutionEnvironment(
                 ExecutionEnvironmentError::UnsupportedExecutionEnvironment("foo".to_string()),
             ),
         ));

--- a/buildpacks/dotnet/src/errors.rs
+++ b/buildpacks/dotnet/src/errors.rs
@@ -2,7 +2,7 @@ use crate::DotnetBuildpackError;
 use crate::dotnet::target_framework_moniker::ParseTargetFrameworkError;
 use crate::dotnet::{project, solution};
 use crate::dotnet_buildpack_configuration::{
-    DotnetBuildpackConfigurationError, ExecutionEnvironmentError,
+    DotnetBuildpackConfigurationError, ExecutionEnvironmentError, ParseVerbosityLevelError,
 };
 use crate::layers::sdk::SdkLayerError;
 use bullet_stream::{Print, fun_run, style};
@@ -262,7 +262,9 @@ fn on_buildpack_error_with_writer(error: &DotnetBuildpackError, mut writer: impl
             ),
         },
         DotnetBuildpackError::ParseBuildpackConfiguration(error) => match error {
-            DotnetBuildpackConfigurationError::InvalidMsbuildVerbosityLevel(verbosity_level) => {
+            DotnetBuildpackConfigurationError::InvalidMsbuildVerbosityLevel(
+                ParseVerbosityLevelError(verbosity_level),
+            ) => {
                 log_error_to(
                     &mut writer,
                     "Invalid MSBuild verbosity level",
@@ -651,7 +653,9 @@ mod tests {
     #[test]
     fn test_parse_buildpack_configuration_invalid_msbuild_verbosity_level_error() {
         assert_error_snapshot(DotnetBuildpackError::ParseBuildpackConfiguration(
-            DotnetBuildpackConfigurationError::InvalidMsbuildVerbosityLevel("Foo".to_string()),
+            DotnetBuildpackConfigurationError::InvalidMsbuildVerbosityLevel(
+                ParseVerbosityLevelError("Foo".to_string()),
+            ),
         ));
     }
 


### PR DESCRIPTION
Small refactoring to clean up the current parsing logic and tests in `dotnet_buildpack_configuration.rs`.

GUS-W-19434368