### PR TITLE
Support `project.toml` configuration

### DIFF
--- a/buildpacks/dotnet/CHANGELOG.md
+++ b/buildpacks/dotnet/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for customizing the default build configuration and MSBuild verbosity level with a `project.toml` file. ([#303](https://github.com/heroku/buildpacks-dotnet/pull/303))
+
 ### Changed
 
 - The buildpack now supports projects using .NET 10.0 preview releases (without custom `global.json` config). ([#301](https://github.com/heroku/buildpacks-dotnet/pull/301))

--- a/buildpacks/dotnet/Cargo.toml
+++ b/buildpacks/dotnet/Cargo.toml
@@ -24,6 +24,7 @@ serde = "1"
 serde_json = "1"
 sha2 = "0.10"
 shell-words = "1"
+toml = "0.9"
 tracing = "0.1"
 
 [dev-dependencies]

--- a/buildpacks/dotnet/src/detect.rs
+++ b/buildpacks/dotnet/src/detect.rs
@@ -38,6 +38,12 @@ pub(crate) fn dotnet_tools_manifest_file<P: AsRef<Path>>(dir: P) -> Option<PathB
     path.is_file().then_some(path)
 }
 
+/// Returns the path to `project.toml` if it exists in the given directory.
+pub(crate) fn project_toml_file<P: AsRef<Path>>(dir: P) -> Option<PathBuf> {
+    let path = dir.as_ref().join("project.toml");
+    path.is_file().then_some(path)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -118,6 +124,34 @@ mod tests {
         fs::create_dir(global_json_path).unwrap();
 
         let result = global_json_file(temp_dir.path());
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_project_toml_file_exists() {
+        let temp_dir = TempDir::new().unwrap();
+        let project_toml_path = temp_dir.path().join("project.toml");
+
+        File::create(&project_toml_path).unwrap();
+
+        let result = project_toml_file(temp_dir.path());
+        assert_eq!(result, Some(project_toml_path));
+    }
+
+    #[test]
+    fn test_project_toml_file_does_not_exist() {
+        let temp_dir = TempDir::new().unwrap();
+        let result = project_toml_file(temp_dir.path());
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_project_toml_file_is_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        let project_toml_path = temp_dir.path().join("project.toml");
+        fs::create_dir(project_toml_path).unwrap();
+
+        let result = project_toml_file(temp_dir.path());
         assert_eq!(result, None);
     }
 }

--- a/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
+++ b/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
@@ -15,7 +15,9 @@ pub(crate) enum DotnetBuildpackConfigurationError {
 }
 
 impl DotnetBuildpackConfiguration {
-    pub(crate) fn try_from(env: &libcnb::Env) -> Result<Self, DotnetBuildpackConfigurationError> {
+    pub(crate) fn try_from_env(
+        env: &libcnb::Env,
+    ) -> Result<Self, DotnetBuildpackConfigurationError> {
         Ok(Self {
             build_configuration: env.get_string_lossy("BUILD_CONFIGURATION"),
             execution_environment: env
@@ -115,7 +117,7 @@ mod tests {
     #[test]
     fn test_default_buildpack_configuration() {
         let env = create_env(&[]);
-        let result = DotnetBuildpackConfiguration::try_from(&env).unwrap();
+        let result = DotnetBuildpackConfiguration::try_from_env(&env).unwrap();
 
         assert_eq!(
             result,
@@ -134,7 +136,7 @@ mod tests {
             ("MSBUILD_VERBOSITY_LEVEL", "Detailed"),
             ("CNB_EXEC_ENV", "test"),
         ]);
-        let result = DotnetBuildpackConfiguration::try_from(&env).unwrap();
+        let result = DotnetBuildpackConfiguration::try_from_env(&env).unwrap();
 
         assert_eq!(result.build_configuration, Some("Release".to_string()));
         assert_eq!(result.execution_environment, ExecutionEnvironment::Test);

--- a/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
+++ b/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
@@ -14,10 +14,8 @@ pub(crate) enum DotnetBuildpackConfigurationError {
     VerbosityLevel(ParseVerbosityLevelError),
 }
 
-impl TryFrom<&libcnb::Env> for DotnetBuildpackConfiguration {
-    type Error = DotnetBuildpackConfigurationError;
-
-    fn try_from(env: &libcnb::Env) -> Result<Self, Self::Error> {
+impl DotnetBuildpackConfiguration {
+    pub(crate) fn try_from(env: &libcnb::Env) -> Result<Self, DotnetBuildpackConfigurationError> {
         Ok(Self {
             build_configuration: env.get_string_lossy("BUILD_CONFIGURATION"),
             execution_environment: env

--- a/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
+++ b/buildpacks/dotnet/src/dotnet_buildpack_configuration.rs
@@ -1,3 +1,4 @@
+use crate::project_toml::DotnetConfig;
 use std::fmt;
 use std::str::FromStr;
 
@@ -15,8 +16,9 @@ pub(crate) enum DotnetBuildpackConfigurationError {
 }
 
 impl DotnetBuildpackConfiguration {
-    pub(crate) fn try_from_env(
+    pub(crate) fn try_from_env_and_project_toml(
         env: &libcnb::Env,
+        _project_toml_config: Option<&DotnetConfig>,
     ) -> Result<Self, DotnetBuildpackConfigurationError> {
         Ok(Self {
             build_configuration: env.get_string_lossy("BUILD_CONFIGURATION"),
@@ -117,7 +119,8 @@ mod tests {
     #[test]
     fn test_default_buildpack_configuration() {
         let env = create_env(&[]);
-        let result = DotnetBuildpackConfiguration::try_from_env(&env).unwrap();
+        let result =
+            DotnetBuildpackConfiguration::try_from_env_and_project_toml(&env, None).unwrap();
 
         assert_eq!(
             result,
@@ -136,7 +139,8 @@ mod tests {
             ("MSBUILD_VERBOSITY_LEVEL", "Detailed"),
             ("CNB_EXEC_ENV", "test"),
         ]);
-        let result = DotnetBuildpackConfiguration::try_from_env(&env).unwrap();
+        let result =
+            DotnetBuildpackConfiguration::try_from_env_and_project_toml(&env, None).unwrap();
 
         assert_eq!(result.build_configuration, Some("Release".to_string()));
         assert_eq!(result.execution_environment, ExecutionEnvironment::Test);

--- a/buildpacks/dotnet/src/errors.rs
+++ b/buildpacks/dotnet/src/errors.rs
@@ -44,6 +44,22 @@ fn on_buildpack_error_with_writer(error: &DotnetBuildpackError, mut writer: impl
             "determining if we must run the Heroku .NET buildpack for this application",
             io_error,
         ),
+        DotnetBuildpackError::ReadProjectTomlFile(io_error) => log_io_error_to(
+            &mut writer,
+            "Error reading `project.toml` file",
+            "reading `project.toml` file",
+            io_error,
+        ),
+        DotnetBuildpackError::ParseProjectToml(error) => log_error_to(
+            &mut writer,
+            "Invalid `project.toml` file",
+            formatdoc! {"
+                We can't parse the `project.toml` file because it contains invalid TOML.
+
+                Use the debug information above to troubleshoot and retry your build.
+            "},
+            Some(error.to_string()),
+        ),
         DotnetBuildpackError::NoSolutionProjects(solution_path) => {
             log_error_to(
                 &mut writer,

--- a/buildpacks/dotnet/src/errors.rs
+++ b/buildpacks/dotnet/src/errors.rs
@@ -484,6 +484,18 @@ mod tests {
     }
 
     #[test]
+    fn test_read_project_toml_file_error() {
+        assert_error_snapshot(DotnetBuildpackError::ReadProjectTomlFile(create_io_error()));
+    }
+
+    #[test]
+    fn test_parse_project_toml_error() {
+        assert_error_snapshot(DotnetBuildpackError::ParseProjectToml(
+            toml::from_str::<toml::Value>("foo").unwrap_err(),
+        ));
+    }
+
+    #[test]
     fn test_no_solution_projects_error() {
         assert_error_snapshot(DotnetBuildpackError::NoSolutionProjects(PathBuf::from(
             "/foo/bar.sln",

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -19,6 +19,7 @@ use crate::dotnet_buildpack_configuration::{
 };
 use crate::dotnet_sdk_command::{DotnetPublishCommand, DotnetTestCommand};
 use crate::layers::sdk::SdkLayerError;
+use crate::project_toml::DotnetConfig;
 use bullet_stream::fun_run::{self, CommandWithName};
 use bullet_stream::global::print;
 use bullet_stream::style;
@@ -65,6 +66,8 @@ impl Buildpack for DotnetBuildpack {
 
     #[allow(clippy::too_many_lines)]
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
+        let project_toml_config = load_project_toml_config(&context.app_dir)?;
+
         let buildpack_configuration = DotnetBuildpackConfiguration::try_from(&Env::from_current())
             .map_err(DotnetBuildpackError::ParseBuildpackConfiguration)?;
 
@@ -226,6 +229,19 @@ impl Buildpack for DotnetBuildpack {
     }
 }
 
+fn load_project_toml_config(app_dir: &Path) -> Result<Option<DotnetConfig>, DotnetBuildpackError> {
+    detect::project_toml_file(app_dir).map_or_else(
+        || Ok(None),
+        |file| {
+            fs_err::read_to_string(file)
+                .map_err(DotnetBuildpackError::ReadProjectTomlFile)
+                .and_then(|content| {
+                    project_toml::parse(&content).map_err(DotnetBuildpackError::ParseProjectToml)
+                })
+        },
+    )
+}
+
 #[instrument(skip_all, err(Debug), fields(
     os.type = %target.os,
     host.arch = %target.arch,
@@ -378,6 +394,8 @@ fn detect_global_json_sdk_configuration(
 #[derive(Debug)]
 enum DotnetBuildpackError {
     BuildpackDetection(io::Error),
+    ReadProjectTomlFile(io::Error),
+    ParseProjectToml(toml::de::Error),
     NoSolutionProjects(PathBuf),
     MultipleRootDirectoryProjectFiles(Vec<PathBuf>),
     LoadSolutionFile(dotnet::solution::LoadError),

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -68,8 +68,9 @@ impl Buildpack for DotnetBuildpack {
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
         let project_toml_config = load_project_toml_config(&context.app_dir)?;
 
-        let buildpack_configuration = DotnetBuildpackConfiguration::try_from(&Env::from_current())
-            .map_err(DotnetBuildpackError::ParseBuildpackConfiguration)?;
+        let buildpack_configuration =
+            DotnetBuildpackConfiguration::try_from_env(&Env::from_current())
+                .map_err(DotnetBuildpackError::ParseBuildpackConfiguration)?;
 
         bullet_stream::global::set_writer(std::io::stdout());
         print::h2("Heroku .NET Buildpack");

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -68,9 +68,11 @@ impl Buildpack for DotnetBuildpack {
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
         let project_toml_config = load_project_toml_config(&context.app_dir)?;
 
-        let buildpack_configuration =
-            DotnetBuildpackConfiguration::try_from_env(&Env::from_current())
-                .map_err(DotnetBuildpackError::ParseBuildpackConfiguration)?;
+        let buildpack_configuration = DotnetBuildpackConfiguration::try_from_env_and_project_toml(
+            &Env::from_current(),
+            project_toml_config.as_ref(),
+        )
+        .map_err(DotnetBuildpackError::ParseBuildpackConfiguration)?;
 
         bullet_stream::global::set_writer(std::io::stdout());
         print::h2("Heroku .NET Buildpack");

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -6,6 +6,7 @@ mod dotnet_sdk_command;
 mod errors;
 mod launch_process;
 mod layers;
+mod project_toml;
 mod utils;
 
 use crate::dotnet::global_json::{GlobalJson, SdkConfig};

--- a/buildpacks/dotnet/src/project_toml.rs
+++ b/buildpacks/dotnet/src/project_toml.rs
@@ -1,0 +1,95 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct ProjectToml {
+    com: Option<ComSection>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ComSection {
+    heroku: Option<HerokuSection>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HerokuSection {
+    buildpacks: Option<BuildpacksSection>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BuildpacksSection {
+    dotnet: Option<DotnetConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct DotnetConfig {
+    pub(crate) msbuild: Option<MsbuildConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct MsbuildConfig {
+    pub(crate) configuration: Option<String>,
+    pub(crate) verbosity: Option<String>,
+}
+
+pub(crate) fn parse(contents: &str) -> Result<Option<DotnetConfig>, toml::de::Error> {
+    toml::from_str::<ProjectToml>(contents).map(|project_toml| {
+        project_toml
+            .com
+            .and_then(|c| c.heroku)
+            .and_then(|h| h.buildpacks)
+            .and_then(|b| b.dotnet)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse() {
+        let project_toml_content = r#"
+[com.heroku.buildpacks.dotnet]
+msbuild.configuration = "Debug"
+msbuild.verbosity = "Detailed"
+"#;
+
+        let result = parse(project_toml_content).unwrap();
+
+        assert!(result.is_some());
+
+        let config = result.unwrap();
+        assert_eq!(
+            config.msbuild.as_ref().unwrap().configuration,
+            Some("Debug".to_string())
+        );
+        assert_eq!(
+            config.msbuild.as_ref().unwrap().verbosity,
+            Some("Detailed".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_missing_dotnet_section() {
+        let project_toml_content = r#"
+[com.heroku.buildpacks.other]
+some.setting = "value"
+"#;
+
+        let result = parse(project_toml_content).unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_parse_invalid_toml() {
+        let project_toml_content = r#"
+[com.heroku.buildpacks.dotnet
+msbuild.configuration = "Debug"
+"#;
+
+        let result = parse(project_toml_content);
+
+        assert!(result.is_err());
+        assert!(matches!(result, Err(toml::de::Error { .. })));
+    }
+}

--- a/buildpacks/dotnet/src/snapshots/parse_project_toml_error.snap
+++ b/buildpacks/dotnet/src/snapshots/parse_project_toml_error.snap
@@ -1,0 +1,15 @@
+---
+source: buildpacks/dotnet/src/errors.rs
+---
+- [1;36mDebug info[0m
+  - TOML parse error at line 1, column 4
+      |
+    1 | foo
+      |    ^
+    key with no value, expected `=`
+
+[0;31m! Invalid `project.toml` file[0m
+[0;31m![0m
+[0;31m! We can't parse the `project.toml` file because it contains invalid TOML.[0m
+[0;31m![0m
+[0;31m! Use the debug information above to troubleshoot and retry your build.[0m

--- a/buildpacks/dotnet/src/snapshots/read_project_toml_file_error.snap
+++ b/buildpacks/dotnet/src/snapshots/read_project_toml_file_error.snap
@@ -1,0 +1,13 @@
+---
+source: buildpacks/dotnet/src/errors.rs
+---
+- [1;36mDebug info[0m
+  - foo bar baz
+
+[0;31m! Error reading `project.toml` file[0m
+[0;31m![0m
+[0;31m! An unexpected I/O error occurred while reading `project.toml` file.[0m
+[0;31m![0m
+[0;31m! Use the debug information above to troubleshoot and retry your build. If the[0m
+[0;31m! issue persists, file an issue here:[0m
+[0;31m! https://github.com/heroku/buildpacks-dotnet/issues/new[0m

--- a/buildpacks/dotnet/tests/dotnet_publish_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_publish_test.rs
@@ -90,6 +90,22 @@ fn test_dotnet_publish_with_debug_configuration() {
 
 #[test]
 #[ignore = "integration test"]
+fn test_dotnet_publish_with_project_toml_configuration() {
+    TestRunner::default().build(
+        default_build_config("tests/fixtures/project_with_project_toml"),
+        |context| {
+            let rid = get_rid();
+            assert_contains!(
+                &context.pack_stdout,
+                &formatdoc! {r#"
+                    - Running `dotnet publish /workspace/foo.csproj --runtime {rid} "-p:PublishDir=bin/publish" --artifacts-path /tmp/build_artifacts --configuration Debug --verbosity quiet`"#}
+            );
+        },
+    );
+}
+
+#[test]
+#[ignore = "integration test"]
 fn test_dotnet_publish_process_registration_with_procfile() {
     TestRunner::default().build(
         default_build_config("tests/fixtures/basic_web_9.0_with_procfile"),

--- a/buildpacks/dotnet/tests/fixtures/project_with_project_toml/foo.csproj
+++ b/buildpacks/dotnet/tests/fixtures/project_with_project_toml/foo.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/buildpacks/dotnet/tests/fixtures/project_with_project_toml/project.toml
+++ b/buildpacks/dotnet/tests/fixtures/project_with_project_toml/project.toml
@@ -1,0 +1,6 @@
+[_]
+schema-version = "0.2"
+
+[com.heroku.buildpacks.dotnet.msbuild]
+configuration = "Debug"
+verbosity = "quiet"


### PR DESCRIPTION
This PR introduces support for customizing the `dotnet publish` [**build configuration** and **verbosity level**](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-publish#options) via a `project.toml` file.

```toml
[_]
schema-version = "0.2"

[com.heroku.buildpacks.dotnet.msbuild]
configuration = "Debug"
verbosity = "quiet"
```

These settings supplement the existing [`BUILD_CONFIGURATION` and `MSBUILD_VERBOSITY_LEVEL` environment variables](https://devcenter.heroku.com/articles/dotnet-behavior-in-heroku#build-configuration). Settings defined in environment variables take precedence over those in `project.toml`.

GUS-W-19426301