### PR TITLE
Improve process detection for nested solutions

### DIFF
--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -26,7 +26,7 @@ fn project_launch_process(
     ) {
         return None;
     }
-    let relative_executable_path = relative_executable_path(app_dir, solution, project);
+    let relative_executable_path = relative_executable_path(app_dir, project);
 
     let command = build_command(&relative_executable_path, project.project_type);
 
@@ -85,7 +85,7 @@ fn project_process_type(project: &Project) -> ProcessType {
 }
 
 /// Returns the (expected) relative executable path from the app directory
-fn relative_executable_path(app_dir: &Path, _solution: &Solution, project: &Project) -> PathBuf {
+fn relative_executable_path(app_dir: &Path, project: &Project) -> PathBuf {
     project_executable_path(project)
         .strip_prefix(app_dir)
         .expect("Executable path should be inside the app directory")
@@ -225,11 +225,6 @@ mod tests {
     #[test]
     fn test_relative_executable_path() {
         let app_dir = Path::new("/tmp");
-        let solution = Solution {
-            path: PathBuf::from("/tmp/solution.sln"),
-            projects: vec![],
-        };
-
         let project = create_test_project(
             "/tmp/project/project.csproj",
             "TestApp",
@@ -237,7 +232,7 @@ mod tests {
         );
 
         assert_eq!(
-            relative_executable_path(app_dir, &solution, &project),
+            relative_executable_path(app_dir, &project),
             PathBuf::from("project/bin/publish/TestApp")
         );
     }

--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -7,9 +7,8 @@ use std::path::{Path, PathBuf};
 
 /// Detects processes in a solution's projects
 pub(crate) fn detect_solution_processes(app_dir: &Path, solution: &Solution) -> Vec<Process> {
-    // First, determine if there is exactly one web application.
-    // This is cheap and avoids complex logic inside the main loop.
-    let is_single_web_app = solution
+    // Check if the solution contains exactly one web application.
+    let has_single_web_app = solution
         .projects
         .iter()
         .filter(|p| p.project_type == ProjectType::WebApplication)
@@ -20,11 +19,10 @@ pub(crate) fn detect_solution_processes(app_dir: &Path, solution: &Solution) -> 
         .projects
         .iter()
         .filter_map(|project| {
-            // Attempt to create a launch process for the project.
             let mut process = project_launch_process(app_dir, project)?;
 
-            // If it's a web app and the only one, override its type to "web".
-            if is_single_web_app && project.project_type == ProjectType::WebApplication {
+            // If it's a web app and the only one, override its type.
+            if has_single_web_app && project.project_type == ProjectType::WebApplication {
                 process.r#type = process_type!("web");
             }
 

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -197,7 +197,8 @@ impl Buildpack for DotnetBuildpack {
 
                 print::bullet("Process types");
                 print::sub_bullet("Detecting process types from published artifacts");
-                let processes = launch_process::detect_solution_processes(&solution);
+                let processes =
+                    launch_process::detect_solution_processes(&context.app_dir, &solution);
                 if processes.is_empty() {
                     print::sub_bullet("No processes were detected");
                 } else {


### PR DESCRIPTION
This PR refactors the launch process detection logic to correctly support solution files located in nested subdirectories.

The original implementation assumed the solution file was at the root of the application directory, causing incorrect relative path calculations for nested solutions (which can now be specified since https://github.com/heroku/buildpacks-dotnet/pull/310).

This change uses the build context's `app_dir` (rather than the solution file's parent directory), ensuring the relative paths in launch process commands are generated correctly.

Additionally, the logic for identifying the single `web` process type has been clarified and simplified for better readability and maintenance.

GUS-W-19560683