### PR TITLE
Improve `dotnet` command failure error messages

### DIFF
--- a/buildpacks/dotnet/CHANGELOG.md
+++ b/buildpacks/dotnet/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Enhanced dotnet command failure error messages with clearer guidance and NuGet status link for troubleshooting. ([#323](https://github.com/heroku/buildpacks-dotnet/pull/323))
+
 ## [0.9.0] - 2025-09-12
 
 ### Changed

--- a/buildpacks/dotnet/src/errors.rs
+++ b/buildpacks/dotnet/src/errors.rs
@@ -349,16 +349,16 @@ fn on_buildpack_error_with_writer(error: &DotnetBuildpackError, mut writer: impl
                 &mut writer,
                 "Unable to restore .NET tools",
                 formatdoc! {"
-                    The `dotnet tool restore` command exited unsuccessfully ({exit_status}).
+                    The `dotnet tool restore` command failed ({exit_status}).
 
-                    This error usually happens due to configuration errors. Use the command output
-                    above to troubleshoot and retry your build.
+                    The most common cause is a configuration error in your tool manifest. Review
+                    the command output above to find and fix the issue.
 
-                    Restoring .NET tools can also fail for a number of other reasons, such as
-                    intermittent network issues, unavailability of the NuGet package feed and/or
-                    other external dependencies, etc.
+                    The failure may also be temporary due to a network or service outage. Retrying
+                    your build often resolves this.
 
-                    Try again to see if the error resolves itself.
+                    If the log suggests a NuGet issue, check the service status before retrying:
+                    https://status.nuget.org
                 ", exit_status = output.status()},
                 None,
             ),
@@ -375,16 +375,16 @@ fn on_buildpack_error_with_writer(error: &DotnetBuildpackError, mut writer: impl
                 &mut writer,
                 "Unable to publish",
                 formatdoc! {"
-                    The `dotnet publish` command exited unsuccessfully ({exit_status}).
+                    The `dotnet publish` command failed ({exit_status}).
 
-                    This error usually happens due to compilation errors. Use the command output
-                    above to troubleshoot and retry your build.
+                    The most common cause is a compilation error. Review the command output above
+                    to find and fix the issue.
 
-                    The publish process can also fail for a number of other reasons, such as
-                    intermittent network issues, unavailability of the NuGet package feed and/or
-                    other external dependencies, etc.
+                    The failure may also be temporary due to a network or service outage. Retrying
+                    your build often resolves this.
 
-                    Try again to see if the error resolves itself.
+                    If the log suggests a NuGet issue, check the service status before retrying:
+                    https://status.nuget.org
                 ", exit_status = output.status()},
                 None,
             ),

--- a/buildpacks/dotnet/src/snapshots/publish_command_non_zero_exit_not_streamed_error.snap
+++ b/buildpacks/dotnet/src/snapshots/publish_command_non_zero_exit_not_streamed_error.snap
@@ -3,13 +3,13 @@ source: buildpacks/dotnet/src/errors.rs
 ---
 [0;31m! Unable to publish[0m
 [0;31m![0m
-[0;31m! The `dotnet publish` command exited unsuccessfully (signal: 5 (SIGTRAP)).[0m
+[0;31m! The `dotnet publish` command failed (signal: 5 (SIGTRAP)).[0m
 [0;31m![0m
-[0;31m! This error usually happens due to compilation errors. Use the command output[0m
-[0;31m! above to troubleshoot and retry your build.[0m
+[0;31m! The most common cause is a compilation error. Review the command output above[0m
+[0;31m! to find and fix the issue.[0m
 [0;31m![0m
-[0;31m! The publish process can also fail for a number of other reasons, such as[0m
-[0;31m! intermittent network issues, unavailability of the NuGet package feed and/or[0m
-[0;31m! other external dependencies, etc.[0m
+[0;31m! The failure may also be temporary due to a network or service outage. Retrying[0m
+[0;31m! your build often resolves this.[0m
 [0;31m![0m
-[0;31m! Try again to see if the error resolves itself.[0m
+[0;31m! If the log suggests a NuGet issue, check the service status before retrying:[0m
+[0;31m! https://status.nuget.org[0m

--- a/buildpacks/dotnet/src/snapshots/restore_dotnet_tools_command_non_zero_exit_not_streamed_error.snap
+++ b/buildpacks/dotnet/src/snapshots/restore_dotnet_tools_command_non_zero_exit_not_streamed_error.snap
@@ -3,13 +3,13 @@ source: buildpacks/dotnet/src/errors.rs
 ---
 [0;31m! Unable to restore .NET tools[0m
 [0;31m![0m
-[0;31m! The `dotnet tool restore` command exited unsuccessfully (signal: 1 (SIGHUP)).[0m
+[0;31m! The `dotnet tool restore` command failed (signal: 1 (SIGHUP)).[0m
 [0;31m![0m
-[0;31m! This error usually happens due to configuration errors. Use the command output[0m
-[0;31m! above to troubleshoot and retry your build.[0m
+[0;31m! The most common cause is a configuration error in your tool manifest. Review[0m
+[0;31m! the command output above to find and fix the issue.[0m
 [0;31m![0m
-[0;31m! Restoring .NET tools can also fail for a number of other reasons, such as[0m
-[0;31m! intermittent network issues, unavailability of the NuGet package feed and/or[0m
-[0;31m! other external dependencies, etc.[0m
+[0;31m! The failure may also be temporary due to a network or service outage. Retrying[0m
+[0;31m! your build often resolves this.[0m
 [0;31m![0m
-[0;31m! Try again to see if the error resolves itself.[0m
+[0;31m! If the log suggests a NuGet issue, check the service status before retrying:[0m
+[0;31m! https://status.nuget.org[0m

--- a/buildpacks/dotnet/tests/dotnet_publish_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_publish_test.rs
@@ -42,16 +42,16 @@ fn test_dotnet_publish_with_compilation_error() {
                 &indoc! {r"
                   ! Unable to publish
                   !
-                  ! The `dotnet publish` command exited unsuccessfully (exit status: 1).
+                  ! The `dotnet publish` command failed (exit status: 1).
                   !
-                  ! This error usually happens due to compilation errors. Use the command output
-                  ! above to troubleshoot and retry your build.
+                  ! The most common cause is a compilation error. Review the command output above
+                  ! to find and fix the issue.
                   !
-                  ! The publish process can also fail for a number of other reasons, such as
-                  ! intermittent network issues, unavailability of the NuGet package feed and/or
-                  ! other external dependencies, etc.
+                  ! The failure may also be temporary due to a network or service outage. Retrying
+                  ! your build often resolves this.
                   !
-                  ! Try again to see if the error resolves itself."}
+                  ! If the log suggests a NuGet issue, check the service status before retrying:
+                  ! https://status.nuget.org"}
             );
         },
     );

--- a/buildpacks/dotnet/tests/dotnet_restore_tools_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_restore_tools_test.rs
@@ -47,16 +47,16 @@ fn test_dotnet_restore_dotnet_tool_with_configuration_error() {
                 &indoc! {r"
                     ! Unable to restore .NET tools
                     !
-                    ! The `dotnet tool restore` command exited unsuccessfully (exit status: 1).
+                    ! The `dotnet tool restore` command failed (exit status: 1).
                     !
-                    ! This error usually happens due to configuration errors. Use the command output
-                    ! above to troubleshoot and retry your build.
+                    ! The most common cause is a configuration error in your tool manifest. Review
+                    ! the command output above to find and fix the issue.
                     !
-                    ! Restoring .NET tools can also fail for a number of other reasons, such as
-                    ! intermittent network issues, unavailability of the NuGet package feed and/or
-                    ! other external dependencies, etc.
+                    ! The failure may also be temporary due to a network or service outage. Retrying
+                    ! your build often resolves this.
                     !
-                    ! Try again to see if the error resolves itself."}
+                    ! If the log suggests a NuGet issue, check the service status before retrying:
+                    ! https://status.nuget.org"}
             );
         },
     );


### PR DESCRIPTION
This PR updates error messages for `dotnet publish` and `dotnet tool restore` failures to be more concise and actionable, and include [NuGet.org service status link](https://status.nuget.org/) for intermittent service-related troubleshooting.

GUS-W-19777370