### PR TITLE
Remove references to CNBs being in preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ for .NET and ASP.NET Core applications. It builds .NET and ASP.NET Core applicat
 minimal configuration.
 
 > [!IMPORTANT]
-> This is a [Cloud Native Buildpack][cnb], and is a component of the [Heroku Cloud Native Buildpacks][heroku-buildpacks] project, which is in preview. If you are instead looking for the Heroku Classic Buildpack for .NET (for use on the Heroku platform), you may find it [here][classic-buildpack].
+> This is a [Cloud Native Buildpack][cnb], and is a component of the [Heroku Cloud Native Buildpacks][heroku-buildpacks] project. If you are instead looking for the Heroku Classic Buildpack for .NET, you may find it [here][classic-buildpack].
 
 ## Usage
 


### PR DESCRIPTION
Since they've been generally available for some time now:
https://www.heroku.com/blog/heroku-fir-generally-available-new-platform-capabilities/

GUS-W-20242644.