### PR TITLE
Improve launch process detection

### DIFF
--- a/buildpacks/dotnet/CHANGELOG.md
+++ b/buildpacks/dotnet/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Process type detection now validates that executables exist before registration and provides detailed analysis output. ([#358](https://github.com/heroku/buildpacks-dotnet/pull/358))
 - Improved `global.json` parsing to validate `rollForward` policy values and provide clearer error messages for invalid SDK versions. ([#357](https://github.com/heroku/buildpacks-dotnet/pull/357))
 
 ## [0.12.0] - 2025-12-04

--- a/buildpacks/dotnet/src/launch_process.rs
+++ b/buildpacks/dotnet/src/launch_process.rs
@@ -32,10 +32,14 @@ pub(crate) fn detect_solution_processes(
     solution
         .projects
         .iter()
-        .filter(|project| matches!(
-            project.project_type,
-            ProjectType::ConsoleApplication | ProjectType::WebApplication | ProjectType::WorkerService
-        ))
+        .filter(|project| {
+            matches!(
+                project.project_type,
+                ProjectType::ConsoleApplication
+                    | ProjectType::WebApplication
+                    | ProjectType::WorkerService
+            )
+        })
         .map(|project| {
             let relative_source = project
                 .path

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -253,14 +253,14 @@ impl Buildpack for DotnetBuildpack {
 
                     // Print all detection results
                     for result in &detection_results {
-                        let message = if result.process.is_some() {
+                        let outcome = if result.process.is_some() {
                             "Found artifact at"
                         } else {
                             "No artifact found at"
                         };
 
                         print::sub_bullet(format!(
-                            "{}: {message} {}",
+                            "{}: {outcome} {}",
                             style::value(result.relative_source.display().to_string()),
                             style::value(result.relative_artifact.display().to_string())
                         ));

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -261,8 +261,8 @@ impl Buildpack for DotnetBuildpack {
 
                         print::sub_bullet(format!(
                             "{}: {outcome} {}",
-                            style::value(result.relative_source.display().to_string()),
-                            style::value(result.relative_artifact.display().to_string())
+                            style::value(result.relative_project_file.display().to_string()),
+                            style::value(result.relative_executable.display().to_string())
                         ));
                     }
 

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -254,9 +254,9 @@ impl Buildpack for DotnetBuildpack {
                     // Print all detection results
                     for result in &detection_results {
                         let outcome = if result.process.is_some() {
-                            "Found artifact at"
+                            "Found executable at"
                         } else {
-                            "No artifact found at"
+                            "No executable found at"
                         };
 
                         print::sub_bullet(format!(

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -270,7 +270,7 @@ impl Buildpack for DotnetBuildpack {
                                 relative_artifact,
                             } => {
                                 print::sub_bullet(format!(
-                                    "{}: Error - Executable not found at {}",
+                                    "{}: No executable found at {}",
                                     style::value(relative_source.display().to_string()),
                                     style::value(relative_artifact.display().to_string())
                                 ));

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -253,20 +253,17 @@ impl Buildpack for DotnetBuildpack {
 
                     // Print all detection results
                     for result in &detection_results {
-                        let source_path_display =
-                            style::value(result.relative_source.display().to_string());
-                        let artifact_path_display =
-                            style::value(result.relative_artifact.display().to_string());
-
-                        if result.process.is_some() {
-                            print::sub_bullet(format!(
-                                "{source_path_display}: Found artifact at {artifact_path_display}"
-                            ));
+                        let message = if result.process.is_some() {
+                            "Found artifact at"
                         } else {
-                            print::sub_bullet(format!(
-                                "{source_path_display}: No artifact found at {artifact_path_display}"
-                            ));
-                        }
+                            "No artifact found at"
+                        };
+
+                        print::sub_bullet(format!(
+                            "{}: {message} {}",
+                            style::value(result.relative_source.display().to_string()),
+                            style::value(result.relative_artifact.display().to_string())
+                        ));
                     }
 
                     // Filter to only valid processes

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -260,7 +260,7 @@ impl Buildpack for DotnetBuildpack {
                                 ..
                             } => {
                                 print::sub_bullet(format!(
-                                    "{}: Found executable at {}",
+                                    "{}: Found artifact at {}",
                                     style::value(relative_source.display().to_string()),
                                     style::value(relative_artifact.display().to_string())
                                 ));
@@ -270,7 +270,7 @@ impl Buildpack for DotnetBuildpack {
                                 relative_artifact,
                             } => {
                                 print::sub_bullet(format!(
-                                    "{}: No executable found at {}",
+                                    "{}: No artifact found at {}",
                                     style::value(relative_source.display().to_string()),
                                     style::value(relative_artifact.display().to_string())
                                 ));

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -253,40 +253,26 @@ impl Buildpack for DotnetBuildpack {
 
                     // Print all detection results
                     for result in &detection_results {
-                        match result {
-                            launch_process::ProcessDetectionResult::Valid {
-                                relative_source,
-                                relative_artifact,
-                                ..
-                            } => {
-                                print::sub_bullet(format!(
-                                    "{}: Found artifact at {}",
-                                    style::value(relative_source.display().to_string()),
-                                    style::value(relative_artifact.display().to_string())
-                                ));
-                            }
-                            launch_process::ProcessDetectionResult::Invalid {
-                                relative_source,
-                                relative_artifact,
-                            } => {
-                                print::sub_bullet(format!(
-                                    "{}: No artifact found at {}",
-                                    style::value(relative_source.display().to_string()),
-                                    style::value(relative_artifact.display().to_string())
-                                ));
-                            }
+                        let source_path_display =
+                            style::value(result.relative_source.display().to_string());
+                        let artifact_path_display =
+                            style::value(result.relative_artifact.display().to_string());
+
+                        if result.process.is_some() {
+                            print::sub_bullet(format!(
+                                "{source_path_display}: Found artifact at {artifact_path_display}"
+                            ));
+                        } else {
+                            print::sub_bullet(format!(
+                                "{source_path_display}: No artifact found at {artifact_path_display}"
+                            ));
                         }
                     }
 
                     // Filter to only valid processes
                     let valid_processes: Vec<_> = detection_results
-                        .iter()
-                        .filter_map(|result| match result {
-                            launch_process::ProcessDetectionResult::Valid { process, .. } => {
-                                Some(process.clone())
-                            }
-                            launch_process::ProcessDetectionResult::Invalid { .. } => None,
-                        })
+                        .into_iter()
+                        .filter_map(|result| result.process)
                         .collect();
 
                     if !valid_processes.is_empty() {

--- a/buildpacks/dotnet/tests/dotnet_publish_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_publish_test.rs
@@ -182,9 +182,10 @@ fn test_dotnet_publish_file_based_app_basic_console() {
                 "- Running `dotnet publish /workspace/foo.cs"
             );
             assert_contains!(context.pack_stdout, "foo -> /workspace/bin/publish/");
+            assert_contains!(context.pack_stdout, "- Analyzing candidates:");
             assert_contains!(
                 context.pack_stdout,
-                "- Found `foo`: bash -c cd bin/publish; ./foo"
+                "- `foo.cs`: Found executable at `bin/publish/foo`"
             );
         },
     );
@@ -210,9 +211,10 @@ fn test_dotnet_publish_file_based_app_basic_web() {
                 "- Running `dotnet publish /workspace/foo.cs"
             );
             assert_contains!(context.pack_stdout, "foo -> /workspace/bin/publish/");
+            assert_contains!(context.pack_stdout, "- Analyzing candidates:");
             assert_contains!(
                 context.pack_stdout,
-                "- Found `web`: bash -c cd bin/publish; ./foo --urls http://*:$PORT"
+                "- `foo.cs`: Found executable at `bin/publish/foo`"
             );
         },
     );
@@ -230,9 +232,12 @@ fn test_dotnet_publish_process_registration_with_procfile() {
                 indoc! { r"
                     - Process types
                       - Detecting process types from published artifacts
-                      - Found `web`: bash -c cd bin/publish; ./foo --urls http://*:$PORT
+                      - Analyzing candidates:
+                      - `foo.csproj`: Found executable at `bin/publish/foo`
                       - Procfile detected
-                      - Skipping process type registration (add process types to your Procfile as needed)"}
+                      - Skipping automatic registration (Procfile takes precedence)
+                      - Available process types (for reference):
+                      - `web`: bash -c cd bin/publish; ./foo --urls http://*:$PORT"}
             );
         },
     );
@@ -250,9 +255,11 @@ fn test_dotnet_publish_process_registration_without_procfile() {
                 indoc! { r"
                 - Process types
                   - Detecting process types from published artifacts
-                  - Found `web`: bash -c cd bin/publish; ./foo --urls http://*:$PORT
+                  - Analyzing candidates:
+                  - `foo.csproj`: Found executable at `bin/publish/foo`
                   - No Procfile detected
-                  - Registering detected process types as launch processes
+                  - Registering launch processes:
+                  - `web`: bash -c cd bin/publish; ./foo --urls http://*:$PORT
                 - Done"}
             );
         },
@@ -271,7 +278,7 @@ fn test_dotnet_publish_process_registration_without_process_types() {
                 indoc! { r"
                 - Process types
                   - Detecting process types from published artifacts
-                  - No processes were detected"}
+                  - No candidate projects detected"}
             );
         },
     );
@@ -326,7 +333,11 @@ fn test_dotnet_publish_with_space_in_project_filename() {
 
             assert_contains!(
                 &context.pack_stdout,
-                r"Found `console-app`: bash -c cd 'console app/bin/publish'; ./'console app'"
+                r"- `console app/console app.csproj`: Found executable at `console app/bin/publish/console app`"
+            );
+            assert_contains!(
+                &context.pack_stdout,
+                r"- `console-app`: bash -c cd 'console app/bin/publish'; ./'console app'"
             );
 
             context.start_container(
@@ -355,10 +366,13 @@ fn test_dotnet_publish_with_updated_process_type_name_heroku_warning() {
                 &formatdoc! {r"
                   - Process types
                     - Detecting process types from published artifacts
-                    - Found `web`: bash -c cd web/bin/publish; ./web --urls http://*:$PORT
-                    - Found `worker`: bash -c cd worker/bin/publish; ./worker
+                    - Analyzing candidates:
+                    - `web/web.csproj`: Found executable at `web/bin/publish/web`
+                    - `worker/worker.csproj`: Found executable at `worker/bin/publish/worker`
                     - No Procfile detected
-                    - Registering detected process types as launch processes
+                    - Registering launch processes:
+                    - `web`: bash -c cd web/bin/publish; ./web --urls http://*:$PORT
+                    - `worker`: bash -c cd worker/bin/publish; ./worker
                   - Done"}
             );
             assert_contains!(context.pack_stdout, "web -> /workspace/web/bin/publish/");
@@ -379,10 +393,13 @@ fn test_dotnet_publish_slnx_with_web_and_console_projects() {
                 &formatdoc! {r"
                   - Process types
                     - Detecting process types from published artifacts
-                    - Found `web`: bash -c cd web/bin/publish; ./web --urls http://*:$PORT
-                    - Found `worker`: bash -c cd worker/bin/publish; ./worker
+                    - Analyzing candidates:
+                    - `web/web.csproj`: Found executable at `web/bin/publish/web`
+                    - `worker/worker.csproj`: Found executable at `worker/bin/publish/worker`
                     - No Procfile detected
-                    - Registering detected process types as launch processes
+                    - Registering launch processes:
+                    - `web`: bash -c cd web/bin/publish; ./web --urls http://*:$PORT
+                    - `worker`: bash -c cd worker/bin/publish; ./worker
                   - Done"}
             );
             assert_contains!(context.pack_stdout, "web -> /workspace/web/bin/publish/");

--- a/buildpacks/dotnet/tests/dotnet_publish_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_publish_test.rs
@@ -185,7 +185,7 @@ fn test_dotnet_publish_file_based_app_basic_console() {
             assert_contains!(context.pack_stdout, "- Analyzing candidates:");
             assert_contains!(
                 context.pack_stdout,
-                "- `foo.cs`: Found executable at `bin/publish/foo`"
+                "- `foo.cs`: Found artifact at `bin/publish/foo`"
             );
         },
     );
@@ -214,7 +214,7 @@ fn test_dotnet_publish_file_based_app_basic_web() {
             assert_contains!(context.pack_stdout, "- Analyzing candidates:");
             assert_contains!(
                 context.pack_stdout,
-                "- `foo.cs`: Found executable at `bin/publish/foo`"
+                "- `foo.cs`: Found artifact at `bin/publish/foo`"
             );
         },
     );
@@ -233,7 +233,7 @@ fn test_dotnet_publish_process_registration_with_procfile() {
                     - Process types
                       - Detecting process types from published artifacts
                       - Analyzing candidates:
-                      - `foo.csproj`: Found executable at `bin/publish/foo`
+                      - `foo.csproj`: Found artifact at `bin/publish/foo`
                       - Procfile detected
                       - Skipping automatic registration (Procfile takes precedence)
                       - Available process types (for reference):
@@ -256,7 +256,7 @@ fn test_dotnet_publish_process_registration_without_procfile() {
                 - Process types
                   - Detecting process types from published artifacts
                   - Analyzing candidates:
-                  - `foo.csproj`: Found executable at `bin/publish/foo`
+                  - `foo.csproj`: Found artifact at `bin/publish/foo`
                   - No Procfile detected
                   - Registering launch processes:
                   - `web`: bash -c cd bin/publish; ./foo --urls http://*:$PORT
@@ -333,7 +333,7 @@ fn test_dotnet_publish_with_space_in_project_filename() {
 
             assert_contains!(
                 &context.pack_stdout,
-                r"- `console app/console app.csproj`: Found executable at `console app/bin/publish/console app`"
+                r"- `console app/console app.csproj`: Found artifact at `console app/bin/publish/console app`"
             );
             assert_contains!(
                 &context.pack_stdout,
@@ -367,8 +367,8 @@ fn test_dotnet_publish_with_updated_process_type_name_heroku_warning() {
                   - Process types
                     - Detecting process types from published artifacts
                     - Analyzing candidates:
-                    - `web/web.csproj`: Found executable at `web/bin/publish/web`
-                    - `worker/worker.csproj`: Found executable at `worker/bin/publish/worker`
+                    - `web/web.csproj`: Found artifact at `web/bin/publish/web`
+                    - `worker/worker.csproj`: Found artifact at `worker/bin/publish/worker`
                     - No Procfile detected
                     - Registering launch processes:
                     - `web`: bash -c cd web/bin/publish; ./web --urls http://*:$PORT
@@ -394,8 +394,8 @@ fn test_dotnet_publish_slnx_with_web_and_console_projects() {
                   - Process types
                     - Detecting process types from published artifacts
                     - Analyzing candidates:
-                    - `web/web.csproj`: Found executable at `web/bin/publish/web`
-                    - `worker/worker.csproj`: Found executable at `worker/bin/publish/worker`
+                    - `web/web.csproj`: Found artifact at `web/bin/publish/web`
+                    - `worker/worker.csproj`: Found artifact at `worker/bin/publish/worker`
                     - No Procfile detected
                     - Registering launch processes:
                     - `web`: bash -c cd web/bin/publish; ./web --urls http://*:$PORT

--- a/buildpacks/dotnet/tests/dotnet_publish_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_publish_test.rs
@@ -185,7 +185,7 @@ fn test_dotnet_publish_file_based_app_basic_console() {
             assert_contains!(context.pack_stdout, "- Analyzing candidates:");
             assert_contains!(
                 context.pack_stdout,
-                "- `foo.cs`: Found artifact at `bin/publish/foo`"
+                "- `foo.cs`: Found executable at `bin/publish/foo`"
             );
         },
     );
@@ -214,7 +214,7 @@ fn test_dotnet_publish_file_based_app_basic_web() {
             assert_contains!(context.pack_stdout, "- Analyzing candidates:");
             assert_contains!(
                 context.pack_stdout,
-                "- `foo.cs`: Found artifact at `bin/publish/foo`"
+                "- `foo.cs`: Found executable at `bin/publish/foo`"
             );
         },
     );
@@ -233,7 +233,7 @@ fn test_dotnet_publish_process_registration_with_procfile() {
                     - Process types
                       - Detecting process types from published artifacts
                       - Analyzing candidates:
-                      - `foo.csproj`: Found artifact at `bin/publish/foo`
+                      - `foo.csproj`: Found executable at `bin/publish/foo`
                       - Procfile detected
                       - Skipping automatic registration (Procfile takes precedence)
                       - Available process types (for reference):
@@ -256,7 +256,7 @@ fn test_dotnet_publish_process_registration_without_procfile() {
                 - Process types
                   - Detecting process types from published artifacts
                   - Analyzing candidates:
-                  - `foo.csproj`: Found artifact at `bin/publish/foo`
+                  - `foo.csproj`: Found executable at `bin/publish/foo`
                   - No Procfile detected
                   - Registering launch processes:
                   - `web`: bash -c cd bin/publish; ./foo --urls http://*:$PORT
@@ -333,7 +333,7 @@ fn test_dotnet_publish_with_space_in_project_filename() {
 
             assert_contains!(
                 &context.pack_stdout,
-                r"- `console app/console app.csproj`: Found artifact at `console app/bin/publish/console app`"
+                r"- `console app/console app.csproj`: Found executable at `console app/bin/publish/console app`"
             );
             assert_contains!(
                 &context.pack_stdout,
@@ -367,8 +367,8 @@ fn test_dotnet_publish_with_updated_process_type_name_heroku_warning() {
                   - Process types
                     - Detecting process types from published artifacts
                     - Analyzing candidates:
-                    - `web/web.csproj`: Found artifact at `web/bin/publish/web`
-                    - `worker/worker.csproj`: Found artifact at `worker/bin/publish/worker`
+                    - `web/web.csproj`: Found executable at `web/bin/publish/web`
+                    - `worker/worker.csproj`: Found executable at `worker/bin/publish/worker`
                     - No Procfile detected
                     - Registering launch processes:
                     - `web`: bash -c cd web/bin/publish; ./web --urls http://*:$PORT
@@ -394,8 +394,8 @@ fn test_dotnet_publish_slnx_with_web_and_console_projects() {
                   - Process types
                     - Detecting process types from published artifacts
                     - Analyzing candidates:
-                    - `web/web.csproj`: Found artifact at `web/bin/publish/web`
-                    - `worker/worker.csproj`: Found artifact at `worker/bin/publish/worker`
+                    - `web/web.csproj`: Found executable at `web/bin/publish/web`
+                    - `worker/worker.csproj`: Found executable at `worker/bin/publish/worker`
                     - No Procfile detected
                     - Registering launch processes:
                     - `web`: bash -c cd web/bin/publish; ./web --urls http://*:$PORT


### PR DESCRIPTION
Previously, the buildpack would detect and register launch processes without validating that the compiled executables actually exist on disk. This could lead to registered process types that would fail at runtime if the publish step didn't produce the expected artifacts.

Additionally, the output only showed which processes were found, making it difficult to diagnose issues when artifacts were missing or located in unexpected places.

## Changes

This PR refactors the process detection logic to implement a "Validate and Report" workflow:

1. **Added validation**: Process detection now checks if each expected executable exists on disk before registering it as a launch process
2. **New result type**: Introduced `ProcessDetectionResult` struct with `relative_project_file`, `relative_executable`, and optional `process` fields to represent detection outcomes
3. **Enhanced output**: Added detailed "Analyzing candidates" section that shows:
   - Valid candidates (with executable): source file and executable location
   - Invalid candidates (missing executable): source file and expected executable location

### Output Format Changes

**Before:**
```
- Process types
  - Detecting process types from published artifacts
  - Found `web`: bash -c cd bin/publish; ./foo --urls http://*:$PORT
  - No Procfile detected
  - Registering detected process types as launch processes
```

**After (with Procfile):**
```
- Process types
  - Detecting process types from published artifacts
  - Analyzing candidates:
  - `Backend/Backend.csproj`: Found executable at `Backend/bin/publish/Backend`
  - Procfile detected
  - Skipping automatic registration (Procfile takes precedence)
  - Available process types (for reference):
  - `web`: bash -c cd Backend/bin/publish; ./Backend --urls http://*:$PORT
```

**After (without Procfile, mixed valid/invalid):**
```
- Process types
  - Detecting process types from published artifacts
  - Analyzing candidates:
  - `Backend/Backend.csproj`: Found executable at `Backend/bin/publish/Backend`
  - `jobs/worker.cs`: No executable found at `jobs/bin/publish/worker`
  - No Procfile detected
  - Registering launch processes:
  - `web`: bash -c cd Backend/bin/publish; ./Backend --urls http://*:$PORT
```

Fixes #351

GUS-W-20371851