### PR TITLE
Update test infrastructure for `heroku/builder:26`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,14 +129,14 @@ jobs:
           path: tmp/guide
       # The images are pulled up front to prevent duplicate pulls due to the tests being run concurrently.
       - name: Pull builder image
-        run: docker pull heroku/builder:24
+        run: docker pull heroku/builder:26
       - name: Pull run image
-        run: docker pull heroku/heroku:24
+        run: docker pull heroku/heroku:26
       - name: Install libcnb-cargo for `cargo libcnb package` command
         run: cargo install libcnb-cargo
       - name: Compile buildpack
         run: cargo libcnb package --target aarch64-unknown-linux-musl
       - name: "PRINT: Getting started guide output"
-        run: pack build my-image --force-color --builder heroku/builder:24 --trust-extra-buildpacks --buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_dotnet --path tmp/guide --pull-policy never
+        run: pack build my-image --force-color --builder heroku/builder:26 --trust-extra-buildpacks --buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_dotnet --path tmp/guide --pull-policy never
       - name: "PRINT: Cached getting started guide output"
-        run: pack build my-image --force-color --builder heroku/builder:24 --trust-extra-buildpacks --buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_dotnet --path tmp/guide --pull-policy never
+        run: pack build my-image --force-color --builder heroku/builder:26 --trust-extra-buildpacks --buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_dotnet --path tmp/guide --pull-policy never

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        builder: ["builder:24", "builder:22"]
+        builder: ["builder:26", "builder:24", "builder:22"]
         arch: ["amd64", "arm64"]
         exclude:
           - builder: "builder:22"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,8 @@ jobs:
         run: cargo install libcnb-cargo
       - name: Compile buildpack
         run: cargo libcnb package --target aarch64-unknown-linux-musl
+      # TODO: Remove `--trust-builder` once `heroku/builder:26` has been added to pack's trusted builders list.
       - name: "PRINT: Getting started guide output"
-        run: pack build my-image --force-color --builder heroku/builder:26 --trust-extra-buildpacks --buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_dotnet --path tmp/guide --pull-policy never
+        run: pack build my-image --force-color --builder heroku/builder:26 --trust-extra-buildpacks --buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_dotnet --path tmp/guide --pull-policy never --trust-builder
       - name: "PRINT: Cached getting started guide output"
-        run: pack build my-image --force-color --builder heroku/builder:26 --trust-extra-buildpacks --buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_dotnet --path tmp/guide --pull-policy never
+        run: pack build my-image --force-color --builder heroku/builder:26 --trust-extra-buildpacks --buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_dotnet --path tmp/guide --pull-policy never --trust-builder

--- a/buildpacks/dotnet/tests/mod.rs
+++ b/buildpacks/dotnet/tests/mod.rs
@@ -20,7 +20,9 @@ pub(crate) fn default_build_config(fixture_path: impl AsRef<Path>) -> BuildConfi
     // to allow configuring the target arch independently of the builder name (eg via env var).
     let target_triple = match builder.as_str() {
         // Compile the buildpack for ARM64 if the builder supports multi-arch and the host is ARM64.
-        "heroku/builder:24" if cfg!(target_arch = "aarch64") => "aarch64-unknown-linux-musl",
+        "heroku/builder:24" | "heroku/builder:26" if cfg!(target_arch = "aarch64") => {
+            "aarch64-unknown-linux-musl"
+        }
         _ => "x86_64-unknown-linux-musl",
     };
     config.target_triple(target_triple);

--- a/buildpacks/dotnet/tests/mod.rs
+++ b/buildpacks/dotnet/tests/mod.rs
@@ -10,8 +10,7 @@ mod runtime_dependencies_test;
 mod sdk_installation_test;
 mod test_execution_environment_test;
 
-// TODO: Update to `heroku/builder:26` after GA
-const DEFAULT_BUILDER: &str = "heroku/builder:24";
+const DEFAULT_BUILDER: &str = "heroku/builder:26";
 
 pub(crate) fn default_build_config(fixture_path: impl AsRef<Path>) -> BuildConfig {
     let builder = builder();

--- a/buildpacks/dotnet/tests/mod.rs
+++ b/buildpacks/dotnet/tests/mod.rs
@@ -10,6 +10,7 @@ mod runtime_dependencies_test;
 mod sdk_installation_test;
 mod test_execution_environment_test;
 
+// TODO: Update to `heroku/builder:26` after GA
 const DEFAULT_BUILDER: &str = "heroku/builder:24";
 
 pub(crate) fn default_build_config(fixture_path: impl AsRef<Path>) -> BuildConfig {


### PR DESCRIPTION
This PR updates the test infrastructure in preparation for `heroku/builder:26`:

- Add `heroku/builder:26` to the CI integration test matrix
- Set `heroku/builder:26` as the default builder for tests and the `print-output` workflow
- Compile the buildpack for ARM64 when using `heroku/builder:26` (same as `heroku/builder:24`)
- Add `--trust-builder` flag to `pack build` command in `print-output` job (since `heroku/builder:26` is not yet in Pack's trusted builders list)

GUS-W-20776048