### PR TITLE
Implement minimal release schedule

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Rebuild Inventory
         id: rebuild-inventory
-        run: cargo run --package inventory-updater buildpacks/dotnet/inventory.toml buildpacks/dotnet/CHANGELOG.md
+        run: cargo run --package inventory-updater buildpacks/dotnet/inventory.toml buildpacks/dotnet/CHANGELOG.md buildpacks/dotnet/release_schedule.toml
 
       - name: Create Pull Request
         id: pr

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,7 @@ dependencies = [
  "sha2",
  "shell-words",
  "tempfile",
+ "time",
  "toml",
  "tracing",
 ]
@@ -1131,8 +1132,7 @@ dependencies = [
 [[package]]
 name = "libherokubuildpack"
 version = "0.30.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e8d088fe5a6a49aecc159edfc61c7833866a8716d4585e10a929fbc213eeb6"
+source = "git+https://github.com/heroku/libcnb.rs?branch=add-release-schedule-module#4e7f77164c353c49619dd39d6559e7276379756d"
 dependencies = [
  "flate2",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -960,6 +961,7 @@ dependencies = [
  "semver",
  "serde",
  "sha2",
+ "time",
  "ureq",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,8 @@ missing_panics_doc = "allow"
 [workspace.dependencies]
 heroku-dotnet-utils = { path = "./shared/dotnet-utils" }
 
+[patch.crates-io]
+libherokubuildpack = { git = "https://github.com/heroku/libcnb.rs", branch = "add-release-schedule-module" }
+
 [profile.release]
 strip = true

--- a/buildpacks/dotnet/Cargo.toml
+++ b/buildpacks/dotnet/Cargo.toml
@@ -24,6 +24,7 @@ serde = "1"
 serde_json = "1"
 sha2 = "0.10"
 shell-words = "1"
+time = { version = "0.3", features = ["macros"] }
 toml = "1.0"
 tracing = "0.1"
 

--- a/buildpacks/dotnet/Cargo.toml
+++ b/buildpacks/dotnet/Cargo.toml
@@ -24,7 +24,7 @@ serde = "1"
 serde_json = "1"
 sha2 = "0.10"
 shell-words = "1"
-time = { version = "0.3", features = ["macros"] }
+time = { version = "0.3", features = ["serde-human-readable"] }
 toml = "1.0"
 tracing = "0.1"
 

--- a/buildpacks/dotnet/release_schedule.toml
+++ b/buildpacks/dotnet/release_schedule.toml
@@ -1,0 +1,11 @@
+[[releases]]
+requirement = "^8.0"
+end_of_life = "2026-11-10"
+
+[[releases]]
+requirement = "^9.0"
+end_of_life = "2026-11-10"
+
+[[releases]]
+requirement = "^10.0"
+end_of_life = "2028-11-14"

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -33,7 +33,7 @@ use crate::utils::{PathsExt, list_files};
 use bullet_stream::fun_run::{self, CommandWithName};
 use bullet_stream::global::print;
 use bullet_stream::style;
-use indoc::printdoc;
+use indoc::{formatdoc, printdoc};
 use inventory::artifact::{Arch, Os};
 use inventory::{Inventory, ParseInventoryError};
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
@@ -46,12 +46,15 @@ use libcnb::layer_env::{LayerEnv, Scope};
 use libcnb::{Buildpack, Env, Target, buildpack_main};
 use libherokubuildpack::inventory;
 use libherokubuildpack::inventory::artifact::Artifact;
+use libherokubuildpack::inventory::schedule::{Release, Schedule};
 use semver::{Version, VersionReq};
 use sha2::Sha512;
 use std::io;
 use std::io::{Write, stderr};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use time::OffsetDateTime;
+use time::macros::date;
 use tracing::instrument;
 
 struct DotnetBuildpack;
@@ -323,13 +326,75 @@ fn resolve_sdk_artifact(
                     sdk_version_requirement,
                 ))
                 .cloned()
-                .inspect(|artifact|
+                .inspect(|artifact| {
                     print::sub_bullet(format!(
                         "Resolved .NET SDK version {} {}",
                         style::value(artifact.version.to_string()),
                         style::details(format!("{}-{}", artifact.os, artifact.arch))
-                    )))
+                    ));
+                    log_release_schedule_warnings(&inventory, artifact);
+                })
         })
+}
+
+fn log_release_schedule_warnings(
+    inventory: &Inventory<Version, Sha512, Option<()>>,
+    artifact: &Artifact<Version, Sha512, Option<()>>,
+) {
+    let schedule = release_schedule();
+    if let Some(release) = schedule.resolve(&artifact.version) {
+        if let Some(latest) = inventory
+            .resolve(artifact.os, artifact.arch, &release.requirement)
+            .filter(|a| a.version > artifact.version)
+        {
+            print::sub_bullet(format!(
+                "{} A newer .NET {} SDK is available (version {})",
+                style::important("Note:"),
+                style::value(release.requirement.to_string()),
+                style::value(latest.version.to_string()),
+            ));
+        }
+
+        if OffsetDateTime::now_utc().date() >= release.end_of_life {
+            let requirement = &release.requirement;
+            let eol_date = release.end_of_life;
+            let support_url = style::url(
+                "https://devcenter.heroku.com/articles/dotnet-heroku-support-reference#net-versions",
+            );
+            print::warning(formatdoc! {"
+                .NET {requirement} reached end-of-life on {eol_date} and is no
+                longer supported on Heroku. End-of-life versions no longer
+                receive security updates or bug fixes from the .NET team.
+
+                To continue receiving updates, upgrade to a supported .NET
+                SDK version. For more information, see:
+                {support_url}
+            "});
+        }
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+fn release_schedule() -> Schedule<VersionReq, time::Date, Option<()>> {
+    Schedule {
+        releases: vec![
+            Release {
+                requirement: VersionReq::parse("^8.0").unwrap(),
+                end_of_life: date!(2026 - 11 - 10),
+                metadata: None,
+            },
+            Release {
+                requirement: VersionReq::parse("^9.0").unwrap(),
+                end_of_life: date!(2026 - 11 - 10),
+                metadata: None,
+            },
+            Release {
+                requirement: VersionReq::parse("^10.0").unwrap(),
+                end_of_life: date!(2028 - 11 - 14),
+                metadata: None,
+            },
+        ],
+    }
 }
 
 #[instrument(skip_all, err(Debug))]

--- a/buildpacks/dotnet/src/main.rs
+++ b/buildpacks/dotnet/src/main.rs
@@ -46,7 +46,7 @@ use libcnb::layer_env::{LayerEnv, Scope};
 use libcnb::{Buildpack, Env, Target, buildpack_main};
 use libherokubuildpack::inventory;
 use libherokubuildpack::inventory::artifact::Artifact;
-use libherokubuildpack::inventory::schedule::{Release, Schedule};
+use libherokubuildpack::inventory::schedule::Schedule;
 use semver::{Version, VersionReq};
 use sha2::Sha512;
 use std::io;
@@ -54,7 +54,6 @@ use std::io::{Write, stderr};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use time::OffsetDateTime;
-use time::macros::date;
 use tracing::instrument;
 
 struct DotnetBuildpack;
@@ -376,25 +375,7 @@ fn log_release_schedule_warnings(
 
 #[allow(clippy::unwrap_used)]
 fn release_schedule() -> Schedule<VersionReq, time::Date, Option<()>> {
-    Schedule {
-        releases: vec![
-            Release {
-                requirement: VersionReq::parse("^8.0").unwrap(),
-                end_of_life: date!(2026 - 11 - 10),
-                metadata: None,
-            },
-            Release {
-                requirement: VersionReq::parse("^9.0").unwrap(),
-                end_of_life: date!(2026 - 11 - 10),
-                metadata: None,
-            },
-            Release {
-                requirement: VersionReq::parse("^10.0").unwrap(),
-                end_of_life: date!(2028 - 11 - 14),
-                metadata: None,
-            },
-        ],
-    }
+    include_str!("../release_schedule.toml").parse().unwrap()
 }
 
 #[instrument(skip_all, err(Debug))]

--- a/buildpacks/dotnet/tests/sdk_installation_test.rs
+++ b/buildpacks/dotnet/tests/sdk_installation_test.rs
@@ -132,9 +132,13 @@ fn test_sdk_installation_with_global_json() {
                       - Detecting version requirement from root global.json file
                       - Detected version requirement: `=8.0.101`
                       - Resolved .NET SDK version `8.0.101` (linux-{artifact_arch})
+                      - Note: A newer .NET `^8.0` SDK is available (version `8.0.")
+            );
+            assert_contains!(
+                context.pack_stdout,
+                &formatdoc!("
                     - SDK installation
-                      - Downloading SDK from https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.101/dotnet-sdk-8.0.101-linux-{dotnet_arch}.tar.gz"
-                )
+                      - Downloading SDK from https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.101/dotnet-sdk-8.0.101-linux-{dotnet_arch}.tar.gz")
             );
             assert_contains!(
                 context.pack_stdout,

--- a/shared/inventory-updater/Cargo.toml
+++ b/shared/inventory-updater/Cargo.toml
@@ -11,7 +11,8 @@ workspace = true
 itertools = "0.14"
 libherokubuildpack = { version = "0.30", default-features = false, features = ["inventory", "inventory-semver", "inventory-sha2"] }
 keep_a_changelog_file = "0.1"
-semver = "1.0"
+semver = { version = "1.0", features = ["serde"] }
 serde = "1"
 sha2 = "0.10"
+time = { version = "0.3", features = ["serde-human-readable", "macros"] }
 ureq = { version = "3", features = ["json"] }

--- a/shared/inventory-updater/src/main.rs
+++ b/shared/inventory-updater/src/main.rs
@@ -4,22 +4,27 @@ use inventory::checksum::Checksum;
 use itertools::Itertools;
 use keep_a_changelog_file::{ChangeGroup, Changelog};
 use libherokubuildpack::inventory;
-use semver::Version;
+use libherokubuildpack::inventory::schedule::Schedule;
+use semver::{Version, VersionReq};
 use serde::Deserialize;
 use sha2::Sha512;
 use std::env;
 use std::fs;
 use std::process;
 use std::str::FromStr;
+use time::Date;
+use time::macros::format_description;
 
 fn main() {
-    let (inventory_path, changelog_path) = {
+    let (inventory_path, changelog_path, schedule_path) = {
         let args: Vec<String> = env::args().collect();
-        if args.len() != 3 {
-            eprintln!("Usage: inventory-updater <path/to/inventory.toml> <path/to/CHANGELOG.md>");
+        if args.len() != 4 {
+            eprintln!(
+                "Usage: inventory-updater <path/to/inventory.toml> <path/to/CHANGELOG.md> <path/to/release_schedule.toml>"
+            );
             process::exit(1);
         }
-        (args[1].clone(), args[2].clone())
+        (args[1].clone(), args[2].clone(), args[3].clone())
     };
 
     let local_inventory = fs::read_to_string(&inventory_path)
@@ -33,7 +38,9 @@ fn main() {
             process::exit(1);
         });
 
-    let mut upstream_artifacts = list_upstream_artifacts();
+    let feeds = fetch_release_feeds();
+
+    let mut upstream_artifacts = list_upstream_artifacts(&feeds);
     upstream_artifacts
         .sort_by_key(|artifact| (artifact.version.clone(), artifact.arch.to_string()));
     let remote_inventory = Inventory {
@@ -70,6 +77,12 @@ fn main() {
         eprintln!("Failed to write to changelog: {e}");
         process::exit(1);
     });
+
+    let schedule = build_release_schedule(&feeds);
+    fs::write(&schedule_path, schedule.to_string()).unwrap_or_else(|e| {
+        eprintln!("Error writing release schedule to file: {e}");
+        process::exit(1);
+    });
 }
 
 /// Finds the difference between two slices.
@@ -98,7 +111,10 @@ fn update_changelog(
 }
 
 #[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
 struct DotNetReleaseFeed {
+    channel_version: String,
+    eol_date: String,
     releases: Vec<Release>,
 }
 
@@ -126,19 +142,27 @@ struct File {
 const SUPPORTED_MAJOR_VERSIONS: &[i32] = &[8, 9, 10];
 const REQUIRED_ARCHS: [Arch; 2] = [Arch::Amd64, Arch::Arm64];
 
-fn list_upstream_artifacts() -> Vec<Artifact<Version, Sha512, Option<()>>> {
+fn fetch_release_feeds() -> Vec<DotNetReleaseFeed> {
     SUPPORTED_MAJOR_VERSIONS
         .iter()
-        .flat_map(|major_version| {
+        .map(|major_version| {
             ureq::get(&format!("https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/{major_version}.0/releases.json"))
                 .call()
                 .expect(".NET release feed should be available")
                 .body_mut()
                 .read_json::<DotNetReleaseFeed>()
                 .expect(".NET release feed should be parsable from JSON")
-                .releases
         })
-        .flat_map(|release| release.sdks)
+        .collect()
+}
+
+fn list_upstream_artifacts(
+    feeds: &[DotNetReleaseFeed],
+) -> Vec<Artifact<Version, Sha512, Option<()>>> {
+    feeds
+        .iter()
+        .flat_map(|feed| &feed.releases)
+        .flat_map(|release| &release.sdks)
         .flat_map(|sdk| {
             REQUIRED_ARCHS.iter().map(move |&arch| {
                 let rid = match arch {
@@ -173,6 +197,28 @@ fn list_upstream_artifacts() -> Vec<Artifact<Version, Sha512, Option<()>>> {
             })
         })
         .collect()
+}
+
+fn build_release_schedule(feeds: &[DotNetReleaseFeed]) -> Schedule<VersionReq, Date, Option<()>> {
+    let date_format = format_description!("[year]-[month]-[day]");
+    let mut schedule = Schedule::new();
+    for feed in feeds {
+        let requirement =
+            VersionReq::parse(&format!("^{}", feed.channel_version)).unwrap_or_else(|e| {
+                panic!(
+                    "Channel version '{}' should be a valid version requirement: {e}",
+                    feed.channel_version
+                )
+            });
+        let eol_date = Date::parse(&feed.eol_date, date_format)
+            .unwrap_or_else(|e| panic!("EOL date '{}' should be a valid date: {e}", feed.eol_date));
+        schedule.push(inventory::schedule::Release {
+            requirement,
+            end_of_life: eol_date,
+            metadata: None,
+        });
+    }
+    schedule
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Minimal implementation to produce EOL warnings and update notices (using the draft `libherokubuildpack` release schedule module https://github.com/heroku/libcnb.rs/pull/989):

* First commit adds the schedule with release data hardcoded to print relevant build log messages.
* Second commit adds logic to write and use the schedule from upstream data.