### PR TITLE
Retry transient HTTP errors when downloading the SDK

### DIFF
--- a/buildpacks/dotnet/CHANGELOG.md
+++ b/buildpacks/dotnet/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Transient HTTP errors (e.g. connection failures, timeouts, 5xx responses) when downloading the .NET SDK now retry, matching the existing behaviour for I/O errors. ([#415](https://github.com/heroku/buildpacks-dotnet/pull/415))
+
 ## [1.0.6] - 2026-04-14
 
 ### Added

--- a/buildpacks/dotnet/src/layers/sdk.rs
+++ b/buildpacks/dotnet/src/layers/sdk.rs
@@ -118,8 +118,19 @@ fn download_sdk(
         }
         match download_result {
             Ok(()) => OperationResult::Ok(()),
-            Err(error @ DownloadError::IoError(_)) => OperationResult::Retry(error),
-            Err(error) => OperationResult::Err(error),
+            Err(error) => {
+                let is_retryable = match &error {
+                    DownloadError::IoError(_) => true,
+                    DownloadError::HttpError(http_error) => http_error
+                        .status()
+                        .is_none_or(|status| !status.is_client_error()),
+                };
+                if is_retryable {
+                    OperationResult::Retry(error)
+                } else {
+                    OperationResult::Err(error)
+                }
+            }
         }
     })
     .map_err(|error| error.error)


### PR DESCRIPTION
The SDK download retry loop currently only retries `DownloadError::IoError`, so transient `reqwest`/HTTP failures aborted the build on the first attempt. However, as noted in the [PR introducing retry logic](https://github.com/heroku/buildpacks-dotnet/pull/140) and #410, we should expand this to also retry certain HTTP errors.

We now also retry `DownloadError::HttpError`, except when the response carries a 4xx status - those indicate a permanent inventory/URL problem and should fail fast. This covers connect/timeout/DNS/TLS failures (no status) and 5xx responses from the CDN.

Fixes #410

GUS-W-22162468