### PR TITLE
Draft changelog template when updating inventory

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -33,13 +33,6 @@ jobs:
         id: rebuild-inventory
         run: cargo run --package inventory-updater buildpacks/dotnet/inventory.toml buildpacks/dotnet/CHANGELOG.md "${RUNNER_TEMP}/announcement"
 
-      - name: Upload announcement
-        if: hashFiles(format('{0}/announcement/body.md', runner.temp)) != ''
-        uses: actions/upload-artifact@v7
-        with:
-          name: announcement
-          path: ${{ runner.temp }}/announcement/
-
       - name: Build PR body
         run: |
           {

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -39,9 +39,7 @@ jobs:
             echo "Automated pull-request to update heroku/dotnet inventory."
             if [ -f "${RUNNER_TEMP}/announcement/body.md" ]; then
               echo
-              echo "## Devcenter changelog announcement"
-              echo
-              echo "Copy these into Devcenter when you're ready to publish."
+              echo "## Dev Center changelog draft"
               echo
               echo "**Title**"
               echo

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Upload announcement
         if: hashFiles(format('{0}/announcement/body.md', runner.temp)) != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: announcement
           path: ${{ runner.temp }}/announcement/

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -31,7 +31,14 @@ jobs:
 
       - name: Rebuild Inventory
         id: rebuild-inventory
-        run: cargo run --package inventory-updater buildpacks/dotnet/inventory.toml buildpacks/dotnet/CHANGELOG.md
+        run: cargo run --package inventory-updater buildpacks/dotnet/inventory.toml buildpacks/dotnet/CHANGELOG.md "${RUNNER_TEMP}/announcement"
+
+      - name: Upload announcement
+        if: hashFiles(format('{0}/announcement/body.md', runner.temp)) != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: announcement
+          path: ${{ runner.temp }}/announcement/
 
       - name: Create Pull Request
         id: pr

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -40,6 +40,30 @@ jobs:
           name: announcement
           path: ${{ runner.temp }}/announcement/
 
+      - name: Build PR body
+        run: |
+          {
+            echo "Automated pull-request to update heroku/dotnet inventory."
+            if [ -f "${RUNNER_TEMP}/announcement/body.md" ]; then
+              echo
+              echo "## Devcenter changelog announcement"
+              echo
+              echo "Copy these into Devcenter when you're ready to publish."
+              echo
+              echo "**Title**"
+              echo
+              echo '```'
+              cat "${RUNNER_TEMP}/announcement/title.md"
+              echo '```'
+              echo
+              echo "**Body**"
+              echo
+              echo '````markdown'
+              cat "${RUNNER_TEMP}/announcement/body.md"
+              echo '````'
+            fi
+          } > "${RUNNER_TEMP}/pr-body.md"
+
       - name: Create Pull Request
         id: pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
@@ -50,7 +74,7 @@ jobs:
           committer: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
           author: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
           branch: update-dotnet-inventory
-          body: "Automated pull-request to update heroku/dotnet inventory"
+          body-path: ${{ runner.temp }}/pr-body.md
 
       - name: Configure PR
         if: steps.pr.outputs.pull-request-operation == 'created'

--- a/shared/inventory-updater/src/main.rs
+++ b/shared/inventory-updater/src/main.rs
@@ -276,12 +276,18 @@ fn build_announcement(
     let mut sentences = Vec::new();
     for (major, runtime_pairs) in &sdks_by_major_and_runtimes {
         // When every SDK in the major shares one runtime pair, use the compact
-        // ".NET X.0 SDK releases include …" form. Otherwise, name the SDKs in
-        // each group so the SDK ↔ runtime mapping is explicit.
+        // ".NET X.0 SDK(s) include …" form. Otherwise, name the SDKs in each
+        // group so the SDK ↔ runtime mapping is explicit.
         if runtime_pairs.len() == 1 {
-            let ((runtime, aspnet), _) = runtime_pairs.iter().next().expect("exactly one entry");
+            let ((runtime, aspnet), sdks) =
+                runtime_pairs.iter().next().expect("exactly one entry");
+            let (noun, verb) = if sdks.len() == 1 {
+                ("SDK", "includes")
+            } else {
+                ("SDKs", "include")
+            };
             sentences.push(format!(
-                "The .NET {major}.0 SDKs include .NET Runtime `{runtime}` and ASP.NET Core Runtime `{aspnet}`."
+                "The .NET {major}.0 {noun} {verb} .NET Runtime `{runtime}` and ASP.NET Core Runtime `{aspnet}`."
             ));
         } else {
             for ((runtime, aspnet), sdks) in runtime_pairs {
@@ -302,10 +308,16 @@ fn build_announcement(
 
     let runtime_paragraph = sentences.join(" ");
 
+    let (title_noun, title_verb, body_noun, body_verb) = if added_versions.len() == 1 {
+        ("SDK", "is", "SDK", "has")
+    } else {
+        ("SDKs", "are", "SDKs", "have")
+    };
+
     Announcement {
-        title: format!(".NET SDK {plain_sdk_list} are now available\n"),
+        title: format!(".NET {title_noun} {plain_sdk_list} {title_verb} now available\n"),
         body: format!(
-            ".NET SDK {backtick_sdk_list} have been made available for builds on Heroku.\n\n{runtime_paragraph}\n\nFor additional information, please see our article on [.NET support](https://devcenter.heroku.com/articles/dotnet-heroku-support-reference).\n",
+            ".NET {body_noun} {backtick_sdk_list} {body_verb} been made available for builds on Heroku.\n\n{runtime_paragraph}\n\nFor additional information, please see our article on [.NET support](https://devcenter.heroku.com/articles/dotnet-heroku-support-reference).\n",
         ),
     }
 }
@@ -437,8 +449,8 @@ mod tests {
             ),
         ]);
 
-        let expected_title = ".NET SDK 8.0.127, 8.0.421, 9.0.117, 9.0.314, 10.0.108, 10.0.204 and 10.0.300 are now available\n";
-        let expected_body = ".NET SDK `8.0.127`, `8.0.421`, `9.0.117`, `9.0.314`, `10.0.108`, `10.0.204` and `10.0.300` have been made available for builds on Heroku.\n\n\
+        let expected_title = ".NET SDKs 8.0.127, 8.0.421, 9.0.117, 9.0.314, 10.0.108, 10.0.204 and 10.0.300 are now available\n";
+        let expected_body = ".NET SDKs `8.0.127`, `8.0.421`, `9.0.117`, `9.0.314`, `10.0.108`, `10.0.204` and `10.0.300` have been made available for builds on Heroku.\n\n\
             The .NET 8.0 SDKs include .NET Runtime `8.0.27` and ASP.NET Core Runtime `8.0.27`. \
             The .NET 9.0 SDKs include .NET Runtime `9.0.16` and ASP.NET Core Runtime `9.0.16`. \
             The .NET 10.0 SDKs include .NET Runtime `10.0.8` and ASP.NET Core Runtime `10.0.8`.\n\n\
@@ -484,9 +496,34 @@ mod tests {
         let announcement = build_announcement(&added, &runtimes);
         assert_eq!(
             announcement.body,
-            ".NET SDK `10.0.108`, `10.0.204` and `10.0.300` have been made available for builds on Heroku.\n\n\
+            ".NET SDKs `10.0.108`, `10.0.204` and `10.0.300` have been made available for builds on Heroku.\n\n\
             .NET SDK `10.0.108` includes .NET Runtime `10.0.7` and ASP.NET Core Runtime `10.0.7`. \
             .NET SDKs `10.0.204` and `10.0.300` include .NET Runtime `10.0.8` and ASP.NET Core Runtime `10.0.9`.\n\n\
+            For additional information, please see our article on [.NET support](https://devcenter.heroku.com/articles/dotnet-heroku-support-reference).\n"
+        );
+    }
+
+    #[test]
+    fn test_build_announcement_handles_single_sdk() {
+        let added = vec![Version::parse("10.0.300").unwrap()];
+
+        let runtimes = HashMap::from([(
+            Version::parse("10.0.300").unwrap(),
+            RuntimeVersions {
+                runtime: Version::parse("10.0.8").unwrap(),
+                aspnetcore_runtime: Version::parse("10.0.8").unwrap(),
+            },
+        )]);
+
+        let announcement = build_announcement(&added, &runtimes);
+        assert_eq!(
+            announcement.title,
+            ".NET SDK 10.0.300 is now available\n"
+        );
+        assert_eq!(
+            announcement.body,
+            ".NET SDK `10.0.300` has been made available for builds on Heroku.\n\n\
+            The .NET 10.0 SDK includes .NET Runtime `10.0.8` and ASP.NET Core Runtime `10.0.8`.\n\n\
             For additional information, please see our article on [.NET support](https://devcenter.heroku.com/articles/dotnet-heroku-support-reference).\n"
         );
     }

--- a/shared/inventory-updater/src/main.rs
+++ b/shared/inventory-updater/src/main.rs
@@ -308,16 +308,16 @@ fn build_announcement(
 
     let runtime_paragraph = sentences.join(" ");
 
-    let (title_noun, title_verb, body_noun, body_verb) = if added_versions.len() == 1 {
-        ("SDK", "is", "SDK", "has")
+    let (noun, title_verb, body_verb) = if added_versions.len() == 1 {
+        ("SDK", "is", "has")
     } else {
-        ("SDKs", "are", "SDKs", "have")
+        ("SDKs", "are", "have")
     };
 
     Announcement {
-        title: format!(".NET {title_noun} {plain_sdk_list} {title_verb} now available\n"),
+        title: format!(".NET {noun} {plain_sdk_list} {title_verb} now available\n"),
         body: format!(
-            ".NET {body_noun} {backtick_sdk_list} {body_verb} been made available for builds on Heroku.\n\n{runtime_paragraph}\n\nFor additional information, please see our article on [.NET support](https://devcenter.heroku.com/articles/dotnet-heroku-support-reference).\n",
+            ".NET {noun} {backtick_sdk_list} {body_verb} been made available for builds on Heroku.\n\n{runtime_paragraph}\n\nFor additional information, please see our article on [.NET support](https://devcenter.heroku.com/articles/dotnet-heroku-support-reference).\n",
         ),
     }
 }

--- a/shared/inventory-updater/src/main.rs
+++ b/shared/inventory-updater/src/main.rs
@@ -300,7 +300,7 @@ fn build_announcement(
                     ("SDKs", "include")
                 };
                 sentences.push(format!(
-                    ".NET {sdk_list} {noun} {verb} .NET Runtime `{runtime}` and ASP.NET Core Runtime `{aspnet}`."
+                    "The .NET {sdk_list} {noun} {verb} .NET Runtime `{runtime}` and ASP.NET Core Runtime `{aspnet}`."
                 ));
             }
         }
@@ -497,8 +497,8 @@ mod tests {
         assert_eq!(
             announcement.body,
             ".NET `10.0.108`, `10.0.204` and `10.0.300` SDKs have been made available for builds on Heroku.\n\n\
-            .NET `10.0.108` SDK includes .NET Runtime `10.0.7` and ASP.NET Core Runtime `10.0.7`. \
-            .NET `10.0.204` and `10.0.300` SDKs include .NET Runtime `10.0.8` and ASP.NET Core Runtime `10.0.9`.\n\n\
+            The .NET `10.0.108` SDK includes .NET Runtime `10.0.7` and ASP.NET Core Runtime `10.0.7`. \
+            The .NET `10.0.204` and `10.0.300` SDKs include .NET Runtime `10.0.8` and ASP.NET Core Runtime `10.0.9`.\n\n\
             For additional information, please see our article on [.NET support](https://devcenter.heroku.com/articles/dotnet-heroku-support-reference).\n"
         );
     }

--- a/shared/inventory-updater/src/main.rs
+++ b/shared/inventory-updater/src/main.rs
@@ -7,19 +7,25 @@ use libherokubuildpack::inventory;
 use semver::Version;
 use serde::Deserialize;
 use sha2::Sha512;
+use std::collections::{BTreeMap, HashMap};
 use std::env;
 use std::fs;
 use std::process;
 use std::str::FromStr;
 
 fn main() {
-    let (inventory_path, changelog_path) = {
+    let (inventory_path, changelog_path, announcement_dir) = {
         let args: Vec<String> = env::args().collect();
-        if args.len() != 3 {
-            eprintln!("Usage: inventory-updater <path/to/inventory.toml> <path/to/CHANGELOG.md>");
-            process::exit(1);
+        match args.len() {
+            3 => (args[1].clone(), args[2].clone(), None),
+            4 => (args[1].clone(), args[2].clone(), Some(args[3].clone())),
+            _ => {
+                eprintln!(
+                    "Usage: inventory-updater <path/to/inventory.toml> <path/to/CHANGELOG.md> [<path/to/announcement-dir>]"
+                );
+                process::exit(1);
+            }
         }
-        (args[1].clone(), args[2].clone())
     };
 
     let local_inventory = fs::read_to_string(&inventory_path)
@@ -33,7 +39,10 @@ fn main() {
             process::exit(1);
         });
 
-    let mut upstream_artifacts = list_upstream_artifacts();
+    let UpstreamData {
+        artifacts: mut upstream_artifacts,
+        sdk_runtimes,
+    } = list_upstream_data();
     upstream_artifacts
         .sort_by_key(|artifact| (artifact.version.clone(), artifact.arch.to_string()));
     let remote_inventory = Inventory {
@@ -55,21 +64,43 @@ fn main() {
         process::exit(1);
     });
 
-    update_changelog(
-        &mut changelog,
-        ChangeGroup::Added,
-        &difference(&remote_inventory.artifacts, &local_inventory.artifacts),
-    );
-    update_changelog(
-        &mut changelog,
-        ChangeGroup::Removed,
-        &difference(&local_inventory.artifacts, &remote_inventory.artifacts),
-    );
+    let added_artifacts = difference(&remote_inventory.artifacts, &local_inventory.artifacts);
+    let removed_artifacts = difference(&local_inventory.artifacts, &remote_inventory.artifacts);
+
+    update_changelog(&mut changelog, ChangeGroup::Added, &added_artifacts);
+    update_changelog(&mut changelog, ChangeGroup::Removed, &removed_artifacts);
 
     fs::write(&changelog_path, changelog.to_string()).unwrap_or_else(|e| {
         eprintln!("Failed to write to changelog: {e}");
         process::exit(1);
     });
+
+    if let Some(dir) = announcement_dir {
+        let added_versions: Vec<Version> = added_artifacts
+            .iter()
+            .map(|artifact| artifact.version.clone())
+            .sorted()
+            .unique()
+            .collect();
+
+        if !added_versions.is_empty() {
+            let announcement = build_announcement(&added_versions, &sdk_runtimes);
+            fs::create_dir_all(&dir).unwrap_or_else(|e| {
+                eprintln!("Failed to create announcement directory '{dir}': {e}");
+                process::exit(1);
+            });
+            let title_path = format!("{dir}/title.md");
+            let body_path = format!("{dir}/body.md");
+            fs::write(&title_path, announcement.title).unwrap_or_else(|e| {
+                eprintln!("Failed to write announcement title to '{title_path}': {e}");
+                process::exit(1);
+            });
+            fs::write(&body_path, announcement.body).unwrap_or_else(|e| {
+                eprintln!("Failed to write announcement body to '{body_path}': {e}");
+                process::exit(1);
+            });
+        }
+    }
 }
 
 /// Finds the difference between two slices.
@@ -105,7 +136,16 @@ struct DotNetReleaseFeed {
 /// Represents a single .NET release within the release feed.
 #[derive(Deserialize)]
 struct Release {
+    runtime: RuntimeComponent,
+    #[serde(rename = "aspnetcore-runtime")]
+    aspnetcore_runtime: RuntimeComponent,
     sdks: Vec<Sdk>,
+}
+
+/// Represents the .NET Runtime or ASP.NET Core Runtime in a release.
+#[derive(Deserialize)]
+struct RuntimeComponent {
+    version: Version,
 }
 
 /// Represents an SDK within a .NET release.
@@ -123,56 +163,168 @@ struct File {
     hash: String,
 }
 
+/// Runtime versions associated with an SDK release.
+struct RuntimeVersions {
+    runtime: Version,
+    aspnetcore_runtime: Version,
+}
+
+/// Data fetched from the upstream .NET release feeds.
+struct UpstreamData {
+    artifacts: Vec<Artifact<Version, Sha512, Option<()>>>,
+    sdk_runtimes: HashMap<Version, RuntimeVersions>,
+}
+
 const SUPPORTED_MAJOR_VERSIONS: &[i32] = &[8, 9, 10];
 const REQUIRED_ARCHS: [Arch; 2] = [Arch::Amd64, Arch::Arm64];
 
-fn list_upstream_artifacts() -> Vec<Artifact<Version, Sha512, Option<()>>> {
-    SUPPORTED_MAJOR_VERSIONS
-        .iter()
-        .flat_map(|major_version| {
-            ureq::get(&format!("https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/{major_version}.0/releases.json"))
-                .call()
-                .expect(".NET release feed should be available")
-                .body_mut()
-                .read_json::<DotNetReleaseFeed>()
-                .expect(".NET release feed should be parsable from JSON")
-                .releases
-        })
-        .flat_map(|release| release.sdks)
-        .flat_map(|sdk| {
-            REQUIRED_ARCHS.iter().map(move |&arch| {
-                let rid = match arch {
-                    Arch::Amd64 => "linux-x64",
-                    Arch::Arm64 => "linux-arm64",
-                };
+fn list_upstream_data() -> UpstreamData {
+    let mut artifacts = Vec::new();
+    let mut sdk_runtimes = HashMap::new();
 
-                // Find the corresponding file in the SDK's file list.
-                // Panic if a required artifact is missing, as we require each version
-                // to support all required platforms.
-                let file = sdk
-                    .files
-                    .iter()
-                    .find(|file| file.rid == rid)
-                    .unwrap_or_else(|| {
-                        panic!(
-                            "SDK version {} is missing the {rid} artifact for Linux.",
-                            sdk.version
-                        )
+    for major_version in SUPPORTED_MAJOR_VERSIONS {
+        let feed = ureq::get(&format!("https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/{major_version}.0/releases.json"))
+            .call()
+            .expect(".NET release feed should be available")
+            .body_mut()
+            .read_json::<DotNetReleaseFeed>()
+            .expect(".NET release feed should be parsable from JSON");
+
+        for release in feed.releases {
+            for sdk in release.sdks {
+                sdk_runtimes.insert(
+                    sdk.version.clone(),
+                    RuntimeVersions {
+                        runtime: release.runtime.version.clone(),
+                        aspnetcore_runtime: release.aspnetcore_runtime.version.clone(),
+                    },
+                );
+
+                for &arch in &REQUIRED_ARCHS {
+                    let rid = match arch {
+                        Arch::Amd64 => "linux-x64",
+                        Arch::Arm64 => "linux-arm64",
+                    };
+
+                    // Find the corresponding file in the SDK's file list.
+                    // Panic if a required artifact is missing, as we require each version
+                    // to support all required platforms.
+                    let file = sdk
+                        .files
+                        .iter()
+                        .find(|file| file.rid == rid)
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "SDK version {} is missing the {rid} artifact for Linux.",
+                                sdk.version
+                            )
+                        });
+
+                    artifacts.push(Artifact {
+                        version: sdk.version.clone(),
+                        os: Os::Linux,
+                        arch,
+                        url: file.url.clone(),
+                        checksum: format!("sha512:{}", file.hash)
+                            .parse::<Checksum<Sha512>>()
+                            .expect("Checksum should be a valid hex-encoded SHA-512 string"),
+                        metadata: None,
                     });
-
-                Artifact {
-                    version: sdk.version.clone(),
-                    os: Os::Linux,
-                    arch,
-                    url: file.url.clone(),
-                    checksum: format!("sha512:{}", file.hash)
-                        .parse::<Checksum<Sha512>>()
-                        .expect("Checksum should be a valid hex-encoded SHA-512 string"),
-                    metadata: None,
                 }
-            })
-        })
-        .collect()
+            }
+        }
+    }
+
+    UpstreamData {
+        artifacts,
+        sdk_runtimes,
+    }
+}
+
+/// Markdown announcement describing newly added SDK versions.
+struct Announcement {
+    title: String,
+    body: String,
+}
+
+/// Renders the announcement title and body for newly added SDK versions.
+fn build_announcement(
+    added_versions: &[Version],
+    sdk_runtimes: &HashMap<Version, RuntimeVersions>,
+) -> Announcement {
+    let backtick_sdk_list = format_version_list(added_versions, "`");
+    let plain_sdk_list = format_version_list(added_versions, "");
+
+    // Group SDKs by major, then by their (runtime, aspnetcore-runtime) pair so
+    // SDKs that share the same runtime versions collapse into a single sentence.
+    let mut sdks_by_major_and_runtimes: BTreeMap<u64, BTreeMap<(Version, Version), Vec<Version>>> =
+        BTreeMap::new();
+    for version in added_versions {
+        if let Some(runtimes) = sdk_runtimes.get(version) {
+            sdks_by_major_and_runtimes
+                .entry(version.major)
+                .or_default()
+                .entry((
+                    runtimes.runtime.clone(),
+                    runtimes.aspnetcore_runtime.clone(),
+                ))
+                .or_default()
+                .push(version.clone());
+        }
+    }
+
+    let mut sentences = Vec::new();
+    for (major, runtime_pairs) in &sdks_by_major_and_runtimes {
+        // When every SDK in the major shares one runtime pair, use the compact
+        // ".NET X.0 SDK releases include …" form. Otherwise, name the SDKs in
+        // each group so the SDK ↔ runtime mapping is explicit.
+        if runtime_pairs.len() == 1 {
+            let ((runtime, aspnet), _) = runtime_pairs.iter().next().expect("exactly one entry");
+            sentences.push(format!(
+                "The .NET {major}.0 SDK releases include .NET Runtime `{runtime}` and ASP.NET Core Runtime `{aspnet}`."
+            ));
+        } else {
+            for ((runtime, aspnet), sdks) in runtime_pairs {
+                let mut sorted_sdks = sdks.clone();
+                sorted_sdks.sort();
+                let sdk_list = format_version_list(&sorted_sdks, "`");
+                let verb = if sorted_sdks.len() == 1 {
+                    "includes"
+                } else {
+                    "include"
+                };
+                sentences.push(format!(
+                    ".NET SDK {sdk_list} {verb} .NET Runtime `{runtime}` and ASP.NET Core Runtime `{aspnet}`."
+                ));
+            }
+        }
+    }
+
+    let runtime_paragraph = sentences.join(" ");
+
+    Announcement {
+        title: format!(".NET SDK {plain_sdk_list} are now available\n"),
+        body: format!(
+            ".NET SDK {backtick_sdk_list} have been made available for builds on Heroku.\n\n{runtime_paragraph}\n\nFor additional information, please see our article on [.NET support](https://devcenter.heroku.com/articles/dotnet-heroku-support-reference).\n",
+        ),
+    }
+}
+
+/// Joins versions into an Oxford-comma list, wrapping each in `wrap` (e.g. backticks).
+fn format_version_list(versions: &[Version], wrap: &str) -> String {
+    let parts: Vec<String> = versions
+        .iter()
+        .map(|v| format!("{wrap}{v}{wrap}"))
+        .collect();
+    match parts.len() {
+        0 => String::new(),
+        1 => parts[0].clone(),
+        2 => format!("{} and {}", parts[0], parts[1]),
+        _ => {
+            let (last, rest) = parts.split_last().expect("non-empty");
+            format!("{} and {last}", rest.join(", "))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -219,5 +371,123 @@ mod tests {
 
         let removed_artifacts = difference(&local_inventory.artifacts, &remote_inventory.artifacts);
         assert!(removed_artifacts.is_empty());
+    }
+
+    #[test]
+    fn test_build_announcement_groups_by_major_version() {
+        let added = vec![
+            Version::parse("8.0.127").unwrap(),
+            Version::parse("8.0.421").unwrap(),
+            Version::parse("9.0.117").unwrap(),
+            Version::parse("9.0.314").unwrap(),
+            Version::parse("10.0.108").unwrap(),
+            Version::parse("10.0.204").unwrap(),
+            Version::parse("10.0.300").unwrap(),
+        ];
+
+        let runtimes = HashMap::from([
+            (
+                Version::parse("8.0.127").unwrap(),
+                RuntimeVersions {
+                    runtime: Version::parse("8.0.27").unwrap(),
+                    aspnetcore_runtime: Version::parse("8.0.27").unwrap(),
+                },
+            ),
+            (
+                Version::parse("8.0.421").unwrap(),
+                RuntimeVersions {
+                    runtime: Version::parse("8.0.27").unwrap(),
+                    aspnetcore_runtime: Version::parse("8.0.27").unwrap(),
+                },
+            ),
+            (
+                Version::parse("9.0.117").unwrap(),
+                RuntimeVersions {
+                    runtime: Version::parse("9.0.16").unwrap(),
+                    aspnetcore_runtime: Version::parse("9.0.16").unwrap(),
+                },
+            ),
+            (
+                Version::parse("9.0.314").unwrap(),
+                RuntimeVersions {
+                    runtime: Version::parse("9.0.16").unwrap(),
+                    aspnetcore_runtime: Version::parse("9.0.16").unwrap(),
+                },
+            ),
+            (
+                Version::parse("10.0.108").unwrap(),
+                RuntimeVersions {
+                    runtime: Version::parse("10.0.8").unwrap(),
+                    aspnetcore_runtime: Version::parse("10.0.8").unwrap(),
+                },
+            ),
+            (
+                Version::parse("10.0.204").unwrap(),
+                RuntimeVersions {
+                    runtime: Version::parse("10.0.8").unwrap(),
+                    aspnetcore_runtime: Version::parse("10.0.8").unwrap(),
+                },
+            ),
+            (
+                Version::parse("10.0.300").unwrap(),
+                RuntimeVersions {
+                    runtime: Version::parse("10.0.8").unwrap(),
+                    aspnetcore_runtime: Version::parse("10.0.8").unwrap(),
+                },
+            ),
+        ]);
+
+        let expected_title = ".NET SDK 8.0.127, 8.0.421, 9.0.117, 9.0.314, 10.0.108, 10.0.204 and 10.0.300 are now available\n";
+        let expected_body = ".NET SDK `8.0.127`, `8.0.421`, `9.0.117`, `9.0.314`, `10.0.108`, `10.0.204` and `10.0.300` have been made available for builds on Heroku.\n\n\
+            The .NET 8.0 SDK releases include .NET Runtime `8.0.27` and ASP.NET Core Runtime `8.0.27`. \
+            The .NET 9.0 SDK releases include .NET Runtime `9.0.16` and ASP.NET Core Runtime `9.0.16`. \
+            The .NET 10.0 SDK releases include .NET Runtime `10.0.8` and ASP.NET Core Runtime `10.0.8`.\n\n\
+            For additional information, please see our article on [.NET support](https://devcenter.heroku.com/articles/dotnet-heroku-support-reference).\n";
+
+        let announcement = build_announcement(&added, &runtimes);
+        assert_eq!(announcement.title, expected_title);
+        assert_eq!(announcement.body, expected_body);
+    }
+
+    #[test]
+    fn test_build_announcement_handles_divergent_runtimes_within_a_major() {
+        let added = vec![
+            Version::parse("10.0.108").unwrap(),
+            Version::parse("10.0.204").unwrap(),
+            Version::parse("10.0.300").unwrap(),
+        ];
+
+        let runtimes = HashMap::from([
+            (
+                Version::parse("10.0.108").unwrap(),
+                RuntimeVersions {
+                    runtime: Version::parse("10.0.7").unwrap(),
+                    aspnetcore_runtime: Version::parse("10.0.7").unwrap(),
+                },
+            ),
+            (
+                Version::parse("10.0.204").unwrap(),
+                RuntimeVersions {
+                    runtime: Version::parse("10.0.8").unwrap(),
+                    aspnetcore_runtime: Version::parse("10.0.9").unwrap(),
+                },
+            ),
+            (
+                Version::parse("10.0.300").unwrap(),
+                RuntimeVersions {
+                    runtime: Version::parse("10.0.8").unwrap(),
+                    aspnetcore_runtime: Version::parse("10.0.9").unwrap(),
+                },
+            ),
+        ]);
+
+        let announcement = build_announcement(&added, &runtimes);
+        assert_eq!(
+            announcement.body,
+            ".NET SDK `10.0.108`, `10.0.204` and `10.0.300` have been made available for builds on Heroku.\n\n\
+            .NET SDK `10.0.108` includes .NET Runtime `10.0.7` and ASP.NET Core Runtime `10.0.7`. \
+            .NET SDK `10.0.204` and `10.0.300` include .NET Runtime `10.0.8` and ASP.NET Core Runtime `10.0.9`.\n\n\
+            For additional information, please see our article on [.NET support](https://devcenter.heroku.com/articles/dotnet-heroku-support-reference).\n"
+        );
     }
 }

--- a/shared/inventory-updater/src/main.rs
+++ b/shared/inventory-updater/src/main.rs
@@ -300,7 +300,7 @@ fn build_announcement(
                     ("SDKs", "include")
                 };
                 sentences.push(format!(
-                    ".NET {noun} {sdk_list} {verb} .NET Runtime `{runtime}` and ASP.NET Core Runtime `{aspnet}`."
+                    ".NET {sdk_list} {noun} {verb} .NET Runtime `{runtime}` and ASP.NET Core Runtime `{aspnet}`."
                 ));
             }
         }
@@ -315,9 +315,9 @@ fn build_announcement(
     };
 
     Announcement {
-        title: format!(".NET {noun} {plain_sdk_list} {title_verb} now available\n"),
+        title: format!(".NET {plain_sdk_list} {noun} {title_verb} now available\n"),
         body: format!(
-            ".NET {noun} {backtick_sdk_list} {body_verb} been made available for builds on Heroku.\n\n{runtime_paragraph}\n\nFor additional information, please see our article on [.NET support](https://devcenter.heroku.com/articles/dotnet-heroku-support-reference).\n",
+            ".NET {backtick_sdk_list} {noun} {body_verb} been made available for builds on Heroku.\n\n{runtime_paragraph}\n\nFor additional information, please see our article on [.NET support](https://devcenter.heroku.com/articles/dotnet-heroku-support-reference).\n",
         ),
     }
 }
@@ -449,8 +449,8 @@ mod tests {
             ),
         ]);
 
-        let expected_title = ".NET SDKs 8.0.127, 8.0.421, 9.0.117, 9.0.314, 10.0.108, 10.0.204 and 10.0.300 are now available\n";
-        let expected_body = ".NET SDKs `8.0.127`, `8.0.421`, `9.0.117`, `9.0.314`, `10.0.108`, `10.0.204` and `10.0.300` have been made available for builds on Heroku.\n\n\
+        let expected_title = ".NET 8.0.127, 8.0.421, 9.0.117, 9.0.314, 10.0.108, 10.0.204 and 10.0.300 SDKs are now available\n";
+        let expected_body = ".NET `8.0.127`, `8.0.421`, `9.0.117`, `9.0.314`, `10.0.108`, `10.0.204` and `10.0.300` SDKs have been made available for builds on Heroku.\n\n\
             The .NET 8.0 SDKs include .NET Runtime `8.0.27` and ASP.NET Core Runtime `8.0.27`. \
             The .NET 9.0 SDKs include .NET Runtime `9.0.16` and ASP.NET Core Runtime `9.0.16`. \
             The .NET 10.0 SDKs include .NET Runtime `10.0.8` and ASP.NET Core Runtime `10.0.8`.\n\n\
@@ -496,9 +496,9 @@ mod tests {
         let announcement = build_announcement(&added, &runtimes);
         assert_eq!(
             announcement.body,
-            ".NET SDKs `10.0.108`, `10.0.204` and `10.0.300` have been made available for builds on Heroku.\n\n\
-            .NET SDK `10.0.108` includes .NET Runtime `10.0.7` and ASP.NET Core Runtime `10.0.7`. \
-            .NET SDKs `10.0.204` and `10.0.300` include .NET Runtime `10.0.8` and ASP.NET Core Runtime `10.0.9`.\n\n\
+            ".NET `10.0.108`, `10.0.204` and `10.0.300` SDKs have been made available for builds on Heroku.\n\n\
+            .NET `10.0.108` SDK includes .NET Runtime `10.0.7` and ASP.NET Core Runtime `10.0.7`. \
+            .NET `10.0.204` and `10.0.300` SDKs include .NET Runtime `10.0.8` and ASP.NET Core Runtime `10.0.9`.\n\n\
             For additional information, please see our article on [.NET support](https://devcenter.heroku.com/articles/dotnet-heroku-support-reference).\n"
         );
     }
@@ -518,11 +518,11 @@ mod tests {
         let announcement = build_announcement(&added, &runtimes);
         assert_eq!(
             announcement.title,
-            ".NET SDK 10.0.300 is now available\n"
+            ".NET 10.0.300 SDK is now available\n"
         );
         assert_eq!(
             announcement.body,
-            ".NET SDK `10.0.300` has been made available for builds on Heroku.\n\n\
+            ".NET `10.0.300` SDK has been made available for builds on Heroku.\n\n\
             The .NET 10.0 SDK includes .NET Runtime `10.0.8` and ASP.NET Core Runtime `10.0.8`.\n\n\
             For additional information, please see our article on [.NET support](https://devcenter.heroku.com/articles/dotnet-heroku-support-reference).\n"
         );

--- a/shared/inventory-updater/src/main.rs
+++ b/shared/inventory-updater/src/main.rs
@@ -279,8 +279,7 @@ fn build_announcement(
         // ".NET X.0 SDK(s) include …" form. Otherwise, name the SDKs in each
         // group so the SDK ↔ runtime mapping is explicit.
         if runtime_pairs.len() == 1 {
-            let ((runtime, aspnet), sdks) =
-                runtime_pairs.iter().next().expect("exactly one entry");
+            let ((runtime, aspnet), sdks) = runtime_pairs.iter().next().expect("exactly one entry");
             let (noun, verb) = if sdks.len() == 1 {
                 ("SDK", "includes")
             } else {
@@ -516,10 +515,7 @@ mod tests {
         )]);
 
         let announcement = build_announcement(&added, &runtimes);
-        assert_eq!(
-            announcement.title,
-            ".NET 10.0.300 SDK is now available\n"
-        );
+        assert_eq!(announcement.title, ".NET 10.0.300 SDK is now available\n");
         assert_eq!(
             announcement.body,
             ".NET `10.0.300` SDK has been made available for builds on Heroku.\n\n\

--- a/shared/inventory-updater/src/main.rs
+++ b/shared/inventory-updater/src/main.rs
@@ -281,20 +281,20 @@ fn build_announcement(
         if runtime_pairs.len() == 1 {
             let ((runtime, aspnet), _) = runtime_pairs.iter().next().expect("exactly one entry");
             sentences.push(format!(
-                "The .NET {major}.0 SDK releases include .NET Runtime `{runtime}` and ASP.NET Core Runtime `{aspnet}`."
+                "The .NET {major}.0 SDKs include .NET Runtime `{runtime}` and ASP.NET Core Runtime `{aspnet}`."
             ));
         } else {
             for ((runtime, aspnet), sdks) in runtime_pairs {
                 let mut sorted_sdks = sdks.clone();
                 sorted_sdks.sort();
                 let sdk_list = format_version_list(&sorted_sdks, "`");
-                let verb = if sorted_sdks.len() == 1 {
-                    "includes"
+                let (noun, verb) = if sorted_sdks.len() == 1 {
+                    ("SDK", "includes")
                 } else {
-                    "include"
+                    ("SDKs", "include")
                 };
                 sentences.push(format!(
-                    ".NET SDK {sdk_list} {verb} .NET Runtime `{runtime}` and ASP.NET Core Runtime `{aspnet}`."
+                    ".NET {noun} {sdk_list} {verb} .NET Runtime `{runtime}` and ASP.NET Core Runtime `{aspnet}`."
                 ));
             }
         }
@@ -439,9 +439,9 @@ mod tests {
 
         let expected_title = ".NET SDK 8.0.127, 8.0.421, 9.0.117, 9.0.314, 10.0.108, 10.0.204 and 10.0.300 are now available\n";
         let expected_body = ".NET SDK `8.0.127`, `8.0.421`, `9.0.117`, `9.0.314`, `10.0.108`, `10.0.204` and `10.0.300` have been made available for builds on Heroku.\n\n\
-            The .NET 8.0 SDK releases include .NET Runtime `8.0.27` and ASP.NET Core Runtime `8.0.27`. \
-            The .NET 9.0 SDK releases include .NET Runtime `9.0.16` and ASP.NET Core Runtime `9.0.16`. \
-            The .NET 10.0 SDK releases include .NET Runtime `10.0.8` and ASP.NET Core Runtime `10.0.8`.\n\n\
+            The .NET 8.0 SDKs include .NET Runtime `8.0.27` and ASP.NET Core Runtime `8.0.27`. \
+            The .NET 9.0 SDKs include .NET Runtime `9.0.16` and ASP.NET Core Runtime `9.0.16`. \
+            The .NET 10.0 SDKs include .NET Runtime `10.0.8` and ASP.NET Core Runtime `10.0.8`.\n\n\
             For additional information, please see our article on [.NET support](https://devcenter.heroku.com/articles/dotnet-heroku-support-reference).\n";
 
         let announcement = build_announcement(&added, &runtimes);
@@ -486,7 +486,7 @@ mod tests {
             announcement.body,
             ".NET SDK `10.0.108`, `10.0.204` and `10.0.300` have been made available for builds on Heroku.\n\n\
             .NET SDK `10.0.108` includes .NET Runtime `10.0.7` and ASP.NET Core Runtime `10.0.7`. \
-            .NET SDK `10.0.204` and `10.0.300` include .NET Runtime `10.0.8` and ASP.NET Core Runtime `10.0.9`.\n\n\
+            .NET SDKs `10.0.204` and `10.0.300` include .NET Runtime `10.0.8` and ASP.NET Core Runtime `10.0.9`.\n\n\
             For additional information, please see our article on [.NET support](https://devcenter.heroku.com/articles/dotnet-heroku-support-reference).\n"
         );
     }


### PR DESCRIPTION
Extend `inventory-updater` to optionally generate a Dev Center changelog draft (title and body) describing the newly added .NET SDK versions and their associated .NET Runtime and ASP.NET Core Runtime versions, sourced from the same upstream release feed the inventory already uses. The Update Inventory GitHub Actions workflow includes that draft in the body of the auto-generated PR so it can be copy-pasted into Dev Center, replacing the manual step of writing announcement copy when bumping the .NET SDK inventory.

Highlights:
- Group SDKs by major version, listing the matching runtime versions per major.
- Fall back to per-SDK sentences when SDKs in the same major ship with divergent runtime versions.
- Handle subject-verb agreement for the single-SDK and multi-SDK cases.
- Generated title is backward-compatible with the language-release-tracker-api Dev Center matcher.
- Unit tests cover the multi-major, single-SDK, and divergent-runtime rendering paths.

Sample PR test showing the PR body updates: https://github.com/heroku/buildpacks-dotnet/pull/424

GUS-W-22466323