### PR TITLE
Drop `--trust-builder` flag from `print-output` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,8 +136,7 @@ jobs:
         run: cargo install libcnb-cargo
       - name: Compile buildpack
         run: cargo libcnb package --target aarch64-unknown-linux-musl
-      # TODO: Remove `--trust-builder` once `heroku/builder:26` has been added to pack's trusted builders list.
       - name: "PRINT: Getting started guide output"
-        run: pack build my-image --force-color --builder heroku/builder:26 --trust-extra-buildpacks --buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_dotnet --path tmp/guide --pull-policy never --trust-builder
+        run: pack build my-image --force-color --builder heroku/builder:26 --trust-extra-buildpacks --buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_dotnet --path tmp/guide --pull-policy never
       - name: "PRINT: Cached getting started guide output"
-        run: pack build my-image --force-color --builder heroku/builder:26 --trust-extra-buildpacks --buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_dotnet --path tmp/guide --pull-policy never --trust-builder
+        run: pack build my-image --force-color --builder heroku/builder:26 --trust-extra-buildpacks --buildpack packaged/aarch64-unknown-linux-musl/debug/heroku_dotnet --path tmp/guide --pull-policy never


### PR DESCRIPTION
`heroku/builder:26` is now on pack's [trusted builders list](https://github.com/buildpacks/pack/pull/2569), shipped in pack v0.40.6, which is the default in [buildpacks/github-actions v5.12.3](https://github.com/buildpacks/github-actions/releases/tag/v5.12.3) — already pinned here as of #429. So `--trust-builder` and its TODO can go.

GUS-W-22518634