### PR TITLE
Fix outdated TFM list in unsupported target framework error

### DIFF
--- a/buildpacks/dotnet/CHANGELOG.md
+++ b/buildpacks/dotnet/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The "Unsupported target framework" error message now lists the actual supported TFMs (`net8.0`, `net9.0`, `net10.0`) instead of stale values. ([#431](https://github.com/heroku/buildpacks-dotnet/pull/431))
+
 ## [1.0.8] - 2026-05-13
 
 ### Added

--- a/buildpacks/dotnet/src/errors.rs
+++ b/buildpacks/dotnet/src/errors.rs
@@ -261,7 +261,7 @@ fn on_buildpack_error_with_writer(error: &DotnetBuildpackError, mut writer: impl
                     "Unsupported target framework",
                     formatdoc! {"
                         The detected target framework moniker `{tfm}` is either invalid or unsupported. This
-                        buildpack currently supports the following TFMs: `net6.0`, `net7.0`, `net8.0`, `net9.0`.
+                        buildpack currently supports the following TFMs: `net8.0`, `net9.0`, `net10.0`.
 
                         For more information, see:
                         https://github.com/heroku/buildpacks-dotnet#net-version

--- a/buildpacks/dotnet/src/snapshots/parse_target_framework_moniker_invalid_format_error.snap
+++ b/buildpacks/dotnet/src/snapshots/parse_target_framework_moniker_invalid_format_error.snap
@@ -5,7 +5,7 @@ source: buildpacks/dotnet/src/errors.rs
 [0;31m! Unsupported target framework[0m
 [0;31m![0m
 [0;31m! The detected target framework moniker `netfoo` is either invalid or unsupported. This[0m
-[0;31m! buildpack currently supports the following TFMs: `net6.0`, `net7.0`, `net8.0`, `net9.0`.[0m
+[0;31m! buildpack currently supports the following TFMs: `net8.0`, `net9.0`, `net10.0`.[0m
 [0;31m![0m
 [0;31m! For more information, see:[0m
 [0;31m! https://github.com/heroku/buildpacks-dotnet#net-version[0m

--- a/buildpacks/dotnet/src/snapshots/parse_target_framework_moniker_unsupported_os_tfm_error.snap
+++ b/buildpacks/dotnet/src/snapshots/parse_target_framework_moniker_unsupported_os_tfm_error.snap
@@ -5,7 +5,7 @@ source: buildpacks/dotnet/src/errors.rs
 [0;31m! Unsupported target framework[0m
 [0;31m![0m
 [0;31m! The detected target framework moniker `net8.0-windows` is either invalid or unsupported. This[0m
-[0;31m! buildpack currently supports the following TFMs: `net6.0`, `net7.0`, `net8.0`, `net9.0`.[0m
+[0;31m! buildpack currently supports the following TFMs: `net8.0`, `net9.0`, `net10.0`.[0m
 [0;31m![0m
 [0;31m! For more information, see:[0m
 [0;31m! https://github.com/heroku/buildpacks-dotnet#net-version[0m


### PR DESCRIPTION
The \"Unsupported target framework\" error message lists `net6.0`, `net7.0`, `net8.0`, `net9.0` as supported TFMs. `net6.0`/`net7.0` aren't in the SDK inventory (resolution would fail), and `net10.0` — supported and documented in the README — is missing.

Updated to list the actually-supported TFMs: `net8.0`, `net9.0`, `net10.0`. Snapshot tests regenerated.

GUS-W-22542017