### PR TITLE
Update default builder to heroku/builder:26

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ or testing this buildpack.
 1. Use the buildpack to build an app: `pack build sample-app --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_dotnet --path /path/to/sample-app`
 
 > [!NOTE]
-> To build an app for a specific architecture (when using a multi-arch builder such as `heroku/builder:24`), you may need or want to explicitly set a couple relevant parameters.
+> To build an app for a specific architecture (when using a multi-arch builder such as `heroku/builder:26`), you may need or want to explicitly set a couple relevant parameters.
 
 * To build the buildpack for ARM64: `cargo libcnb package --target aarch64-unknown-linux-musl`.
 * To build an app for a different architecture: `pack build sample-app --buildpack packaged/x86_64-unknown-linux-musl/debug/heroku_dotnet --platform linux/amd64`

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To build a .NET application codebase into a production image:
 
 ```bash
 $ cd ~/workdir/sample-dotnet-app
-$ pack build sample-app --builder heroku/builder:24
+$ pack build sample-app --builder heroku/builder:26
 ```
 
 Then run the image:
@@ -73,7 +73,7 @@ Set the `SOLUTION_FILE` environment variable during build:
 ```bash
 $ pack build sample-app \
     --env "SOLUTION_FILE=foo.sln" \
-    --builder heroku/builder:24
+    --builder heroku/builder:26
 ```
 
 #### Using project.toml
@@ -112,7 +112,7 @@ To build using a `Debug` build configuration and `detailed` verbosity level:
 $ pack build sample-app \
     --env "BUILD_CONFIGURATION=Debug" \
     --env "MSBUILD_VERBOSITY_LEVEL=detailed" \
-    --builder heroku/builder:24
+    --builder heroku/builder:26
 ```
 
 > [!NOTE]


### PR DESCRIPTION
Updates the README and CONTRIBUTING usage examples to use
heroku/builder:26.

GUS-W-22580946.