### PR TITLE
Remove obsolete `STACK` env var from publish integration tests

### DIFF
--- a/buildpacks/dotnet/tests/dotnet_publish_test.rs
+++ b/buildpacks/dotnet/tests/dotnet_publish_test.rs
@@ -350,34 +350,9 @@ fn test_dotnet_publish_with_space_in_project_filename() {
 
 #[test]
 #[ignore = "integration test"]
-fn test_dotnet_publish_with_updated_process_type_name_heroku_warning() {
-    TestRunner::default().build(
-        default_build_config("tests/fixtures/solution_with_web_and_console_projects")
-            .env("STACK", "heroku-24"),
-        |context| {
-            assert_empty!(context.pack_stderr);
-            assert_contains!(
-                context.pack_stdout,
-                &formatdoc! {r"
-                  - Process types
-                    - Detecting process types from published artifacts
-                    - Found `web`: bash -c cd web/bin/publish; ./web --urls http://*:$PORT
-                    - Found `worker`: bash -c cd worker/bin/publish; ./worker
-                    - No Procfile detected
-                    - Registering detected process types as launch processes
-                  - Done"}
-            );
-            assert_contains!(context.pack_stdout, "web -> /workspace/web/bin/publish/");
-        },
-    );
-}
-
-#[test]
-#[ignore = "integration test"]
 fn test_dotnet_publish_slnx_with_web_and_console_projects_and_directory_build_props() {
     TestRunner::default().build(
-        default_build_config("tests/fixtures/solution_slnx_with_web_and_console_projects")
-            .env("STACK", "heroku-24"),
+        default_build_config("tests/fixtures/solution_slnx_with_web_and_console_projects"),
         |context| {
             assert_empty!(context.pack_stderr);
             assert_contains!(


### PR DESCRIPTION
`test_dotnet_publish_with_updated_process_type_name_heroku_warning` was added in #252 to verify a launch-process-type rename warning that only fired for `heroku-*` stacks (which is why it set `STACK=heroku-24`). That warning was removed in #275, leaving the test asserting only generic process-type detection output already covered by `test_dotnet_publish_multi_tfm_solution` and the SLNX test, so delete it.

`test_dotnet_publish_slnx_with_web_and_console_projects_and_directory_build_props` inherited the same `STACK=heroku-24` env via copy/paste and never needed it — drop that too.

GUS-W-22596382