### PR TITLE
Enable libcnb Dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,20 @@ updates:
       - "rust"
       - "skip changelog"
     groups:
+      libcnb:
+        patterns:
+          - "libcnb"
+          - "libcnb-*"
+          - "libherokubuildpack"
       rust-dependencies:
         update-types:
           - "minor"
           - "patch"
+        # Work around: https://github.com/dependabot/dependabot-core/issues/11093
+        exclude-patterns:
+          - "libcnb"
+          - "libcnb-*"
+          - "libherokubuildpack"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,17 +33,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -908,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -1056,9 +1045,9 @@ checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libcnb"
-version = "0.30.4"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0850585e823ab396809d2793d89aee3cb766dda8842db6492d463c766db514a8"
+checksum = "00fabff1700918032e8247da8be15881311766ae5847604445a600160bd29488"
 dependencies = [
  "libcnb-common",
  "libcnb-data",
@@ -1077,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-common"
-version = "0.30.4"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dcbb67b3f0075de818046a674c3e6f4cd59e78c8e5d1716f768799460451ec4"
+checksum = "37fe6255e60d54d345ceb872c1ec4ab246354270476c5b925546f56ffd8240e5"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -1088,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-data"
-version = "0.30.4"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65a8aea899a7a5260fb06ee629887bdc97c23169969d7c26252c0654116756c8"
+checksum = "69904cf6f9d446ec0a763a806d4ac8077a9c9460cb3d403c2160810d8539daa1"
 dependencies = [
  "fancy-regex",
  "libcnb-proc-macros",
@@ -1102,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-package"
-version = "0.30.4"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdc4184afd713861b296dd886491765cf8c151c5c2608d467cd42077efe9db2"
+checksum = "6bfcc8dcb67cbdd8938a47ce415cef965bfa186f645106e109f90f16f69cb297"
 dependencies = [
  "cargo_metadata",
  "ignore",
@@ -1119,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-proc-macros"
-version = "0.30.4"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ce63474a40ddad15c3405e069d7fa1bed0fddad0da742c9b910a94d6ea415d"
+checksum = "b5a207308d8093481af32e1c123e194e1efcf176be02c08e33b8f576eb479b62"
 dependencies = [
  "cargo_metadata",
  "fancy-regex",
@@ -1131,9 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-test"
-version = "0.30.4"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161b455750a654bff60d6304232b2e86f442b80f6e2b34f089caa0581f5f8f02"
+checksum = "407969fa14d54e38d42fb7eed735573e8862d56b3e4472fc39bc6c4ceba597ef"
 dependencies = [
  "fastrand",
  "fs_extra",
@@ -1289,9 +1278,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1302,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "base64",
  "const-hex",
@@ -1312,22 +1301,20 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "serde",
- "serde_json",
- "tonic",
- "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand",
  "thiserror 2.0.18",
 ]
@@ -1350,26 +1337,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1386,6 +1353,12 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1535,9 +1508,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1964,9 +1937,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2146,17 +2119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-stream"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2194,38 +2156,6 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
-
-[[package]]
-name = "tonic"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
-dependencies = [
- "async-trait",
- "base64",
- "bytes",
- "http",
- "http-body",
- "http-body-util",
- "percent-encoding",
- "pin-project",
- "sync_wrapper",
- "tokio-stream",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic-prost"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
-dependencies = [
- "bytes",
- "prost",
- "tonic",
-]
 
 [[package]]
 name = "tower"
@@ -2317,9 +2247,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",
@@ -2634,9 +2564,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
  "libc",
 ]

--- a/buildpacks/dotnet/Cargo.toml
+++ b/buildpacks/dotnet/Cargo.toml
@@ -14,8 +14,8 @@ bullet_stream = "0.11"
 fs-err = "3"
 hex = "0.4"
 indoc = "2"
-libcnb = { version = "0.30", features = ["trace"] }
-libherokubuildpack = { version = "0.31", default-features = false, features = ["tar", "download", "inventory", "inventory-semver", "inventory-sha2"] }
+libcnb = { version = "=0.31.0", features = ["trace"] }
+libherokubuildpack = { version = "=0.31.0", default-features = false, features = ["tar", "download", "inventory", "inventory-semver", "inventory-sha2"] }
 quick-xml = { version = "0.41", features = ["serialize"] }
 regex = "1"
 retry = { version = "2", default-features = false }
@@ -29,5 +29,5 @@ tracing = "0.1"
 
 [dev-dependencies]
 insta = "1"
-libcnb-test = "0.30"
+libcnb-test = "=0.31.0"
 tempfile = "3"

--- a/shared/inventory-updater/Cargo.toml
+++ b/shared/inventory-updater/Cargo.toml
@@ -9,7 +9,7 @@ workspace = true
 
 [dependencies]
 itertools = "0.15"
-libherokubuildpack = { version = "0.31", default-features = false, features = ["inventory", "inventory-semver", "inventory-sha2"] }
+libherokubuildpack = { version = "=0.31.0", default-features = false, features = ["inventory", "inventory-semver", "inventory-sha2"] }
 keep_a_changelog_file = "0.1"
 semver = "1.0"
 serde = "1"


### PR DESCRIPTION
Add a `libcnb` Dependabot group so the libcnb-family crates (`libcnb`, `libcnb-*` and `libherokubuildpack`) are updated together in a single PR, rather than split across the general `rust-dependencies` group.

Dependabot's grouping docs state that when multiple groups are specified, the first group defined wins:
https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--

In practice this is broken: PRs are compared against all groups and can end up in a later group whose settings then prevent the PR being opened - so major libcnb updates were misrouted to `rust-dependencies` and filtered out by its `update-types: ["minor", "patch"]` rule, meaning no PR was opened at all. To work around this, the groups are made non-overlapping by adding a matching `exclude-patterns` to `rust-dependencies`.

See:
https://github.com/dependabot/dependabot-core/issues/11093

See also: https://github.com/heroku/buildpacks-nodejs/pull/1408

The libcnb-family crate versions have also been pinned to exact versions using the `=` syntax, since these crates have a large impact on the behaviour of the buildpack, so we want to control their version more carefully. (We used to pin to an exact version in many CNBs in the past, but removed the pin as part of trying to work out why Dependabot wasn't updating.)

The libcnb-family crates had drifted out of sync (`libcnb` and `libcnb-test` were on `0.30.4` while `libherokubuildpack` was on `0.31.0`); they are now aligned to `0.31.0`, the most recent of the versions already in use.

GUS-W-23329202.
